### PR TITLE
fix: add prisma generate to deployment startup sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "switch-db": "node switch-db.js",
     "dev": "npm run switch-db && tsx watch src/index.ts",
     "build": "npm run switch-db && tsc && prisma generate",
-    "start": "npm run switch-db && node scripts/remove-migration-lock.js && prisma migrate deploy && node dist/deploy-commands.js && node dist/index.js",
+    "start": "npm run switch-db && node scripts/remove-migration-lock.js && prisma generate && prisma migrate deploy && node dist/deploy-commands.js && node dist/index.js",
     "start:local": "npm run switch-db && node dist/index.js",
     "deploy": "tsx src/deploy-commands.ts",
     "deploy:commands": "node dist/deploy-commands.js",


### PR DESCRIPTION
## Summary

Fixes Railway deployment failures caused by Prisma provider mismatch error (P3019).

## Problem

Deployment was failing with:
```
Error: P3019
The datasource provider `postgresql` specified in your schema does not match 
the one specified in the migration_lock.toml, `sqlite`.
```

## Root Cause

The startup sequence was removing the old migration lock but not regenerating the Prisma client with the new provider configuration. This left the Prisma client with stale SQLite provider internals when attempting migrations.

## Solution

Added `prisma generate` after removing the migration lock in the `start` script. The corrected sequence:

1. Switch schema to PostgreSQL (via `switch-db.js`)
2. Remove old SQLite migration lock (via `remove-migration-lock.js`)
3. **Regenerate Prisma client with PostgreSQL provider** (NEW)
4. Deploy migrations
5. Start bot

## Testing

This ensures the Prisma client is regenerated with the correct provider before migrations attempt to run, resolving the provider mismatch error that was blocking Railway deployments.