### PR TITLE
Restructure commands: /stats for analytics, /raid for archiving

### DIFF
--- a/docs/feature-manifest.json
+++ b/docs/feature-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "updated_at": "2026-03-16",
+  "updated_at": "2026-03-21",
   "tagline": "Discord bot for WoW raid attendance management with reverse sign-up",
   "description": "RaidPresence uses a reverse sign-up system where all eligible guild members are automatically signed up for raids and must opt-out if they cannot attend — reducing friction and improving attendance visibility.",
   "supported_languages": ["en", "de"],
@@ -41,8 +41,9 @@
       "status": "live",
       "summary": "Track player attendance history, reliability metrics, and opt-out patterns across raids.",
       "landing_copy": "Know who shows up. Attendance history and reliability scores help you plan with confidence.",
-      "docs_url": "docs/commands/RAID-COMMAND.md",
+      "docs_url": "docs/commands/STATS-COMMAND.md",
       "commands": ["attendance"],
+      "command_prefix": "/stats",
       "since": "0.0.1"
     },
     {
@@ -52,19 +53,9 @@
       "status": "live",
       "summary": "Analyze raid composition by role (tank, healer, melee DPS, ranged DPS) with optimization suggestions.",
       "landing_copy": "See your comp at a glance — tanks, healers, melee, and ranged with smart suggestions.",
-      "docs_url": "docs/commands/RAID-COMMAND.md",
+      "docs_url": "docs/commands/STATS-COMMAND.md",
       "commands": ["suggest"],
-      "since": "0.0.1"
-    },
-    {
-      "id": "opt-out-notes",
-      "name": "Opt-out Tracking with Notes",
-      "category": "core",
-      "status": "partial",
-      "summary": "Players can opt out of raids with a reason. The /raid notes subcommand to view opt-out reasons is not yet wired up.",
-      "landing_copy": "Players explain why they can't make it. Leaders see every note at a glance.",
-      "docs_url": "docs/commands/RAID-COMMAND.md",
-      "commands": [],
+      "command_prefix": "/stats",
       "since": "0.0.1"
     },
     {
@@ -82,11 +73,11 @@
       "id": "archive-system",
       "name": "Raid Archiving",
       "category": "commands",
-      "status": "partial",
-      "summary": "Archive completed raids to a dedicated channel. The archive, unarchive, and search subcommands exist as dead code but are not registered under any live command.",
+      "status": "live",
+      "summary": "Archive completed raids to a dedicated channel, with search across archived raids by name, player, or date.",
       "landing_copy": "Completed raids move to your archive channel automatically. Search past raids anytime.",
       "docs_url": "docs/commands/RAID-COMMAND.md",
-      "commands": [],
+      "commands": ["archive", "unarchive", "search"],
       "since": "0.1.0"
     },
     {
@@ -106,8 +97,9 @@
       "status": "live",
       "summary": "View a dashboard of all upcoming raids with roster counts and status.",
       "landing_copy": "See every upcoming raid, who's in, and who's out — all in one view.",
-      "docs_url": "docs/commands/RAID-COMMAND.md",
+      "docs_url": "docs/commands/STATS-COMMAND.md",
       "commands": ["status"],
+      "command_prefix": "/stats",
       "since": "0.0.1"
     },
     {
@@ -175,10 +167,17 @@
   "commands_summary": [
     {
       "name": "/raid",
-      "subcommand_count": 14,
-      "description": "Raid lifecycle and analytics — create, list, delete, close, open, cancel, remind, refresh, edit, clone, stats, status, attendance, suggest",
+      "subcommand_count": 13,
+      "description": "Raid lifecycle and archiving — create, list, delete, close, open, cancel, remind, refresh, edit, clone, archive, unarchive, search",
       "status": "live",
       "docs_url": "docs/commands/RAID-COMMAND.md"
+    },
+    {
+      "name": "/stats",
+      "subcommand_count": 5,
+      "description": "Statistics and analytics — raid, guild, status, attendance, suggest",
+      "status": "live",
+      "docs_url": "docs/commands/STATS-COMMAND.md"
     },
     {
       "name": "/config",
@@ -206,14 +205,14 @@
     {
       "id": "raid-pin",
       "name": "/raid pin",
-      "replaced_by": "Archive subcommand (not yet wired up under /raid)",
+      "replaced_by": "/raid archive",
       "deprecated_in": "0.1.0",
       "removal_target": "1.0.0"
     },
     {
       "id": "raid-unpin",
       "name": "/raid unpin",
-      "replaced_by": "Unarchive subcommand (not yet wired up under /raid)",
+      "replaced_by": "/raid unarchive",
       "deprecated_in": "0.1.0",
       "removal_target": "1.0.0"
     }

--- a/docs/feature-manifest.json
+++ b/docs/feature-manifest.json
@@ -41,7 +41,7 @@
       "status": "live",
       "summary": "Track player attendance history, reliability metrics, and opt-out patterns across raids.",
       "landing_copy": "Know who shows up. Attendance history and reliability scores help you plan with confidence.",
-      "docs_url": "docs/commands/STATS-COMMAND.md",
+      "docs_url": "docs/commands/RAID-COMMAND.md",
       "commands": ["attendance"],
       "command_prefix": "/stats",
       "since": "0.0.1"
@@ -53,7 +53,7 @@
       "status": "live",
       "summary": "Analyze raid composition by role (tank, healer, melee DPS, ranged DPS) with optimization suggestions.",
       "landing_copy": "See your comp at a glance — tanks, healers, melee, and ranged with smart suggestions.",
-      "docs_url": "docs/commands/STATS-COMMAND.md",
+      "docs_url": "docs/commands/RAID-COMMAND.md",
       "commands": ["suggest"],
       "command_prefix": "/stats",
       "since": "0.0.1"
@@ -97,7 +97,7 @@
       "status": "live",
       "summary": "View a dashboard of all upcoming raids with roster counts and status.",
       "landing_copy": "See every upcoming raid, who's in, and who's out — all in one view.",
-      "docs_url": "docs/commands/STATS-COMMAND.md",
+      "docs_url": "docs/commands/RAID-COMMAND.md",
       "commands": ["status"],
       "command_prefix": "/stats",
       "since": "0.0.1"
@@ -177,7 +177,7 @@
       "subcommand_count": 5,
       "description": "Statistics and analytics — raid, guild, status, attendance, suggest",
       "status": "live",
-      "docs_url": "docs/commands/STATS-COMMAND.md"
+      "docs_url": "docs/commands/RAID-COMMAND.md"
     },
     {
       "name": "/config",

--- a/src/commands/__tests__/integration/phase1.integration.test.ts
+++ b/src/commands/__tests__/integration/phase1.integration.test.ts
@@ -470,7 +470,7 @@ describe('Phase 1 Integration Tests', () => {
         editReply: jest.fn().mockResolvedValue(undefined),
         reply: jest.fn().mockResolvedValue(undefined),
         options: {
-          getSubcommand: jest.fn().mockReturnValue('stats'),
+          getSubcommand: jest.fn().mockReturnValue('guild'),
           get: jest.fn((key: string, required?: boolean) => {
             const opts: Record<string, any> = {
               raid_id: undefined,
@@ -481,7 +481,7 @@ describe('Phase 1 Integration Tests', () => {
         },
       };
 
-      await command.execute(guildStatsInteraction);
+      await statsCommand.execute(guildStatsInteraction);
 
       // ── Step 3: Verify guild stats ──────────────────────────────
       const replyArg = guildStatsInteraction.editReply.mock.calls[0][0];
@@ -759,7 +759,7 @@ describe('Phase 1 Integration Tests', () => {
         },
       };
 
-      await command.execute(statusInteraction);
+      await statsCommand.execute(statusInteraction);
 
       // ── Step 3: Verify status dashboard ─────────────────────────
       // 3a: Correct DB query

--- a/src/commands/__tests__/integration/raid-archive.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-archive.integration.test.ts
@@ -18,7 +18,7 @@ jest.mock('discord.js', () => {
   };
 });
 
-import command from '../../stats';
+import command from '../../raid';
 
 // ─── Tests ────────────────────────────────────────────────────────
 

--- a/src/commands/__tests__/integration/raid-attendance.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-attendance.integration.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
 
 import prisma from '../../../database/client';
-import command from '../../raid';
+import command from '../../stats';
 
 // ─── Helpers ──────────────────────────────────────────────────────
 

--- a/src/commands/__tests__/integration/raid-status.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-status.integration.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
 
 import prisma from '../../../database/client';
-import command from '../../raid';
+import command from '../../stats';
 
 // ─── Helpers ──────────────────────────────────────────────────────
 

--- a/src/commands/__tests__/integration/raid-suggest.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-suggest.integration.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
 
 import prisma from '../../../database/client';
-import command from '../../raid';
+import command from '../../stats';
 
 // ─── Helpers ──────────────────────────────────────────────────────
 

--- a/src/commands/__tests__/performance/phase1.performance.test.ts
+++ b/src/commands/__tests__/performance/phase1.performance.test.ts
@@ -15,6 +15,7 @@ jest.mock('../../../utils/permissions');
 
 import prisma from '../../../database/client';
 import command from '../../raid';
+import statsCommand from '../../stats';
 import { calculateRaidStats, calculateGuildStats } from '../../../utils/statsCalculator';
 import { formatStatusEmbed, StatusRaid } from '../../../utils/statusFormatter';
 import { formatRaidStatsEmbed, formatGuildStatsEmbed } from '../../../utils/statsFormatter';
@@ -276,7 +277,7 @@ describe('Phase 1 Performance Tests', () => {
         editReply: jest.fn().mockResolvedValue(undefined),
         reply: jest.fn().mockResolvedValue(undefined),
         options: {
-          getSubcommand: jest.fn().mockReturnValue('stats'),
+          getSubcommand: jest.fn().mockReturnValue('guild'),
           get: jest.fn((key: string) => {
             if (key === 'period') return { value: 'month' };
             return undefined;
@@ -285,7 +286,7 @@ describe('Phase 1 Performance Tests', () => {
       };
 
       const elapsed = await measureTime(async () => {
-        await command.execute(interaction);
+        await statsCommand.execute(interaction);
       });
 
       expect(elapsed).toBeLessThan(200);
@@ -530,7 +531,7 @@ describe('Phase 1 Performance Tests', () => {
       };
 
       const elapsed = await measureTime(async () => {
-        await command.execute(interaction);
+        await statsCommand.execute(interaction);
       });
 
       expect(elapsed).toBeLessThan(500);

--- a/src/commands/__tests__/raid-attendance.test.ts
+++ b/src/commands/__tests__/raid-attendance.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../utils/attendanceAnalytics', () => {
 });
 
 import prisma from '../../database/client';
-import command from '../raid';
+import command from '../stats';
 import {
   calculatePlayerStats,
   getPlayerRoleDistribution,

--- a/src/commands/__tests__/raid-stats.test.ts
+++ b/src/commands/__tests__/raid-stats.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
 
 import prisma from '../../database/client';
-import command from '../raid';
+import command from '../stats';
 
 // Build a mock interaction for the stats subcommand
 function buildMockInteraction(optionOverrides: Record<string, any> = {}, extras: Record<string, any> = {}) {
@@ -19,6 +19,9 @@ function buildMockInteraction(optionOverrides: Record<string, any> = {}, extras:
     period: undefined,
     ...optionOverrides,
   };
+
+  // Determine subcommand: 'raid' if raid_id is provided, 'guild' otherwise
+  const subcommand = options.raid_id ? 'raid' : 'guild';
 
   const mockInteraction: any = {
     isChatInputCommand: jest.fn().mockReturnValue(true),
@@ -38,7 +41,7 @@ function buildMockInteraction(optionOverrides: Record<string, any> = {}, extras:
     editReply: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockResolvedValue(undefined),
     options: {
-      getSubcommand: jest.fn().mockReturnValue('stats'),
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
       get: jest.fn((key: string, required?: boolean) => {
         return options[key] || (required ? { value: null } : undefined);
       }),
@@ -92,7 +95,7 @@ function makeRaid(overrides: Record<string, any> = {}) {
   };
 }
 
-describe('/raid stats command', () => {
+describe('/stats command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (canManageRaids as jest.Mock).mockResolvedValue(true);
@@ -119,7 +122,7 @@ describe('/raid stats command', () => {
       expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
       expect(prisma.raid.findUnique).toHaveBeenCalledWith({
         where: { id: 'raid-1' },
-        include: { attendance: true },
+        include: { attendance: true, guild: true },
       });
 
       // Should editReply with an embed

--- a/src/commands/__tests__/raid-status.test.ts
+++ b/src/commands/__tests__/raid-status.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
 
 import prisma from '../../database/client';
-import command from '../raid';
+import command from '../stats';
 
 function buildMockInteraction(extras: Record<string, any> = {}) {
   const mockInteraction: any = {

--- a/src/commands/__tests__/security.test.ts
+++ b/src/commands/__tests__/security.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../utils/permissions');
 
 import prisma from '../../database/client';
 import command from '../raid';
+import statsCommand from '../stats';
 
 // Minimal Collection-like Map supporting discord.js `.some()` and `.filter()`
 class MockCollection<K, V> extends Map<K, V> {
@@ -176,8 +177,6 @@ describe('Security & Data Integrity', () => {
     );
 
     const readOnlyCommands = [
-      { subcommand: 'stats', options: {} },
-      { subcommand: 'status', options: {} },
       { subcommand: 'list', options: {} },
     ];
 
@@ -248,7 +247,7 @@ describe('Security & Data Integrity', () => {
       }
     );
 
-    it('should reject /raid stats with raid_id from another guild', async () => {
+    it('should reject /stats raid with raid_id from another guild', async () => {
       const otherGuildRaid = makeRaid({
         id: 'raid-other',
         guildId: 'other-guild-999',
@@ -260,19 +259,19 @@ describe('Security & Data Integrity', () => {
       });
       (prisma.raid.findUnique as jest.Mock).mockResolvedValue(otherGuildRaid);
 
-      const interaction = buildInteraction('stats', {
+      const interaction = buildInteraction('raid', {
         raid_id: { value: 'raid-other' },
         period: undefined,
       });
 
-      await command.execute(interaction);
+      await statsCommand.execute(interaction);
 
       const editReplyCall = interaction.editReply.mock.calls[0]?.[0];
       const content = editReplyCall?.content || '';
       expect(content).toMatch(/does not belong|not.*server|not found/i);
     });
 
-    it('should scope /raid status query to requesting guild only', async () => {
+    it('should scope /stats status query to requesting guild only', async () => {
       (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
         id: 'guild-123',
         language: 'en',
@@ -280,7 +279,7 @@ describe('Security & Data Integrity', () => {
       (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
 
       const interaction = buildInteraction('status', {});
-      await command.execute(interaction);
+      await statsCommand.execute(interaction);
 
       expect(prisma.raid.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -306,18 +305,18 @@ describe('Security & Data Integrity', () => {
       );
     });
 
-    it('should scope /raid stats guild-wide query to requesting guild only', async () => {
+    it('should scope /stats guild query to requesting guild only', async () => {
       (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
         id: 'guild-123',
         language: 'en',
       });
       (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
 
-      const interaction = buildInteraction('stats', {
+      const interaction = buildInteraction('guild', {
         raid_id: undefined,
         period: { value: 'month' },
       });
-      await command.execute(interaction);
+      await statsCommand.execute(interaction);
 
       expect(prisma.raid.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -494,7 +493,7 @@ describe('Security & Data Integrity', () => {
   describe('Guild context required', () => {
     const allCommands = [
       'clone', 'remind', 'delete', 'close', 'cancel', 'refresh',
-      'edit', 'stats', 'status', 'list', 'create',
+      'edit', 'list', 'create',
     ];
 
     it.each(allCommands)(

--- a/src/commands/__tests__/ux-verification.test.ts
+++ b/src/commands/__tests__/ux-verification.test.ts
@@ -13,6 +13,7 @@ import { formatRaidStatsEmbed, formatGuildStatsEmbed } from '../../utils/statsFo
 import { formatStatusEmbed, getRosterStatus } from '../../utils/statusFormatter';
 import { calculateRaidStats, calculateGuildStats, getReliabilityScore } from '../../utils/statsCalculator';
 import command from '../raid';
+import statsCommand from '../stats';
 
 // ============================================================
 // 1. Error Messages: Clear and Helpful
@@ -124,12 +125,12 @@ describe('UX: Slash Command Registration', () => {
     const subcommands = (commandJson.options || []).filter(
       (opt: any) => opt.type === 1 // SUB_COMMAND type
     );
-    expect(subcommands.length).toBe(14);
+    expect(subcommands.length).toBe(13);
 
     const names = subcommands.map((s: any) => s.name).sort();
     expect(names).toEqual([
-      'attendance', 'cancel', 'clone', 'close', 'create', 'delete',
-      'edit', 'list', 'open', 'refresh', 'remind', 'stats', 'status', 'suggest',
+      'archive', 'cancel', 'clone', 'close', 'create', 'delete',
+      'edit', 'list', 'open', 'refresh', 'remind', 'search', 'unarchive',
     ]);
   });
 
@@ -157,14 +158,22 @@ describe('UX: Slash Command Registration', () => {
     }
   });
 
-  it('Phase 1 subcommands are present: clone, stats, status', () => {
+  it('Phase 1 subcommands are present: clone on /raid, stats/status on /stats', () => {
     const subcommands = (commandJson.options || []).filter(
       (opt: any) => opt.type === 1
     );
     const names = subcommands.map((s: any) => s.name);
     expect(names).toContain('clone');
-    expect(names).toContain('stats');
-    expect(names).toContain('status');
+
+    // stats and status now live on /stats command
+    const statsJson = statsCommand.data.toJSON() as any;
+    const statsSubcommands = (statsJson.options || []).filter(
+      (opt: any) => opt.type === 1
+    );
+    const statsNames = statsSubcommands.map((s: any) => s.name);
+    expect(statsNames).toContain('raid');
+    expect(statsNames).toContain('guild');
+    expect(statsNames).toContain('status');
   });
 
   it('clone subcommand has correct options', () => {
@@ -185,7 +194,8 @@ describe('UX: Slash Command Registration', () => {
   });
 
   it('attendance subcommand has period option with correct choices', () => {
-    const attendanceSub = (commandJson.options || []).find(
+    const statsJson = statsCommand.data.toJSON() as any;
+    const attendanceSub = (statsJson.options || []).find(
       (opt: any) => opt.name === 'attendance'
     );
     expect(attendanceSub).toBeDefined();
@@ -193,13 +203,14 @@ describe('UX: Slash Command Registration', () => {
     expect(periodOpt).toBeDefined();
     expect(periodOpt.choices).toHaveLength(3);
     const choiceValues = periodOpt.choices.map((c: any) => c.value);
-    expect(choiceValues).toContain('30');
-    expect(choiceValues).toContain('90');
+    expect(choiceValues).toContain('month');
+    expect(choiceValues).toContain('quarter');
     expect(choiceValues).toContain('all');
   });
 
   it('status subcommand has no required options', () => {
-    const statusSub = (commandJson.options || []).find(
+    const statsJson = statsCommand.data.toJSON() as any;
+    const statusSub = (statsJson.options || []).find(
       (opt: any) => opt.name === 'status'
     );
     expect(statusSub).toBeDefined();

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -323,7 +323,7 @@ async function handleSetArchiveChannel(interaction: ChatInputCommandInteraction)
   });
 
   await interaction.editReply({
-    content: `✅ Archive channel set to <#${channel.id}>.\n\nClosed raids can now be archived to this channel using \`/stats archive\`.`,
+    content: `✅ Archive channel set to <#${channel.id}>.\n\nClosed raids can now be archived to this channel using \`/raid archive\`.`,
   });
 }
 

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -14,15 +14,9 @@ import { Command } from '../types';
 import { getSpecRole, getSpecSymbol, RoleComposition } from '../utils/wowData';
 import { canManageRaids } from '../utils/permissions';
 import { t, getTranslations } from '../utils/localization';
-import { calculateRaidStats, calculateGuildStats } from '../utils/statsCalculator';
-import type { AttendanceRecord } from '../utils/statsCalculator';
-import { formatRaidStatsEmbed, formatGuildStatsEmbed } from '../utils/statsFormatter';
-import { formatStatusEmbed } from '../utils/statusFormatter';
 import { VERSION } from '../utils/version';
-import { calculatePlayerStats, getPlayerRoleDistribution, getPlayerAttendanceHistory } from '../utils/attendanceAnalytics';
-import { formatAttendanceEmbed } from '../utils/attendanceFormatter';
-import { analyzeRaidComposition, findCompositionGaps, suggestPlayerSwaps, calculateSuccessLikelihood, CompositionAttendee } from '../utils/compositionAnalyzer';
-import { formatCompositionEmbed } from '../utils/compositionFormatter';
+import { archiveRaid, unarchiveRaid, searchArchive } from '../utils/archiveManager';
+import { formatArchiveSearchEmbed } from '../utils/archiveFormatter';
 import { isRateLimitError, handleRateLimitError, fetchMembersWithRateLimitHandling } from '../utils/rateLimitHandler';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
 
@@ -313,49 +307,50 @@ const command: Command = {
              .setRequired(false)
          )
        )
-        .addSubcommand((subcommand) =>
-          subcommand
-            .setName('stats')
-          .setDescription('View attendance statistics')
-      )
       .addSubcommand((subcommand) =>
         subcommand
-          .setName('status')
-          .setDescription('View status dashboard of upcoming raids')
-      )
-      .addSubcommand((subcommand) =>
-        subcommand
-          .setName('attendance')
-          .setDescription('View player attendance history')
-          .addUserOption((option) =>
+          .setName('archive')
+          .setDescription('Archive a raid to keep history clean')
+          .addStringOption((option) =>
             option
-              .setName('player')
-              .setDescription('The player to view attendance for')
+              .setName('raid_id')
+              .setDescription('The raid to archive')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand((subcommand) =>
+        subcommand
+          .setName('unarchive')
+          .setDescription('Restore an archived raid')
+          .addStringOption((option) =>
+            option
+              .setName('raid_id')
+              .setDescription('The raid to restore')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand((subcommand) =>
+        subcommand
+          .setName('search')
+          .setDescription('Search archived raids')
+          .addStringOption((option) =>
+            option
+              .setName('query')
+              .setDescription('Search query (raid name, player, date)')
               .setRequired(true)
           )
           .addStringOption((option) =>
             option
               .setName('period')
-              .setDescription('Time period for attendance history')
-              .setRequired(true)
+              .setDescription('Time period to search')
               .addChoices(
-                { name: '30 days', value: '30' },
-                { name: '90 days', value: '90' },
-                { name: 'All-time', value: 'all' },
+                { name: 'Last 30 days', value: 'month' },
+                { name: 'Last 90 days', value: 'quarter' },
+                { name: 'All time', value: 'all' }
               )
+              .setRequired(false)
           )
       )
-      .addSubcommand((subcommand) =>
-        subcommand
-          .setName('suggest')
-          .setDescription('Analyze raid composition and suggest improvements')
-          .addStringOption((option) =>
-            option
-              .setName('raid_id')
-               .setDescription('The ID of the raid to analyze')
-               .setRequired(true)
-           )
-       )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents) as SlashCommandBuilder,
 
   async execute(interaction: CommandInteraction) {
@@ -383,14 +378,12 @@ const command: Command = {
         await handleEditRaid(interaction);
      } else if (subcommand === 'clone') {
          await handleCloneRaid(interaction);
-      } else if (subcommand === 'stats') {
-      await handleRaidStats(interaction);
-    } else if (subcommand === 'status') {
-      await handleRaidStatus(interaction);
-    } else if (subcommand === 'attendance') {
-      await handleRaidAttendance(interaction);
-    } else if (subcommand === 'suggest') {
-      await handleRaidSuggest(interaction);
+    } else if (subcommand === 'archive') {
+      await handleArchiveRaid(interaction);
+    } else if (subcommand === 'unarchive') {
+      await handleUnarchiveRaid(interaction);
+    } else if (subcommand === 'search') {
+      await handleSearchArchive(interaction);
     }
   }
 };
@@ -1435,7 +1428,7 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
 
 
 
-async function handleRaidStats(interaction: ChatInputCommandInteraction) {
+async function handleArchiveRaid(interaction: ChatInputCommandInteraction) {
   if (!interaction.guild) {
     await interaction.reply({
       content: '❌ This command can only be used in a server!',
@@ -1446,80 +1439,31 @@ async function handleRaidStats(interaction: ChatInputCommandInteraction) {
 
   await interaction.deferReply({ ephemeral: true });
 
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
-  if (!guildData) {
+  // Check permissions
+  const member = interaction.member;
+  if (!member || !(await canManageRaids(member as any))) {
     await interaction.editReply({
-      content: '❌ Guild not found in database.',
+      content: '❌ You do not have permission to archive raids. Ask your server admin to configure raid leader roles.',
     });
     return;
   }
 
-  // Check if raid_id parameter is provided for per-raid stats
-  const raidId = interaction.options.get('raid_id', false)?.value as string | undefined;
+  const raidId = interaction.options.get('raid_id', true).value as string;
 
-  if (raidId) {
-    // Per-raid stats
-    const raid = await prisma.raid.findUnique({
-      where: { id: raidId },
-      include: { attendance: true },
+  try {
+    await archiveRaid(raidId, interaction.guild!.id, interaction.client);
+    await interaction.editReply({
+      content: '✅ Raid archived successfully.',
     });
-
-    if (!raid) {
-      await interaction.editReply({
-        content: '❌ Raid not found.',
-      });
-      return;
-    }
-
-    if (raid.guildId !== interaction.guild.id) {
-      await interaction.editReply({
-        content: '❌ This raid does not belong to this server.',
-      });
-      return;
-    }
-
-    const stats = calculateRaidStats(raid.attendance);
-    const embed = formatRaidStatsEmbed(raid, stats, guildData.language || 'en');
-
-    await interaction.editReply({ embeds: [embed] });
-  } else {
-    // Guild-wide stats
-    // Get period parameter (default: 'month')
-    const periodValue = interaction.options.get('period', false)?.value as string || 'month';
-    
-    let startDate: Date;
-    let period: 'week' | 'month' | 'all' = 'month';
-    
-    if (periodValue === 'week') {
-      startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // Last 7 days
-      period = 'week';
-    } else if (periodValue === 'all') {
-      startDate = new Date(0); // Epoch start (all time)
-      period = 'all';
-    } else {
-      startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // Last 30 days
-      period = 'month';
-    }
-    
-    const raids = await prisma.raid.findMany({
-      where: {
-        guildId: interaction.guild.id,
-        raidDate: { gte: startDate },
-      },
-      include: { attendance: true },
+  } catch (error) {
+    console.error('Error archiving raid:', error);
+    await interaction.editReply({
+      content: '❌ Failed to archive raid.',
     });
-
-    const stats = calculateGuildStats(raids);
-    const embed = formatGuildStatsEmbed(stats, period, guildData.language || 'en');
-
-    await interaction.editReply({ embeds: [embed] });
   }
 }
 
-async function handleRaidStatus(interaction: ChatInputCommandInteraction) {
+async function handleUnarchiveRaid(interaction: ChatInputCommandInteraction) {
   if (!interaction.guild) {
     await interaction.reply({
       content: '❌ This command can only be used in a server!',
@@ -1530,70 +1474,28 @@ async function handleRaidStatus(interaction: ChatInputCommandInteraction) {
 
   await interaction.deferReply({ ephemeral: true });
 
-  const now = new Date();
-  const raids = await prisma.raid.findMany({
-    where: {
-      guildId: interaction.guild.id,
-      status: 'open',
-      raidDate: {
-        gte: now,
-      },
-    },
-    orderBy: {
-      raidDate: 'asc',
-    },
-    take: 7,
-    include: {
-      attendance: true,
-    },
-  });
-
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
-  const embed = formatStatusEmbed(raids, guildData?.language || 'en');
-
-  await interaction.editReply({ embeds: [embed] });
-}
-
-async function handleRaidAttendance(interaction: ChatInputCommandInteraction) {
-  if (!interaction.guild) {
-    await interaction.reply({
-      content: '❌ This command can only be used in a server!',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  await interaction.deferReply({ ephemeral: true });
-
-  const player = interaction.options.get('player', true).user!;
-  const periodValue = interaction.options.get('period', false)?.value as string || '30';
-
-  let period: string;
-  if (periodValue === '30' || periodValue === 'month') period = 'month';
-  else if (periodValue === '90' || periodValue === 'quarter') period = 'quarter';
-  else period = 'all';
-
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
-  if (!guildData) {
+  // Check permissions
+  const member = interaction.member;
+  if (!member || !(await canManageRaids(member as any))) {
     await interaction.editReply({
-      content: '❌ Guild not found in database.',
+      content: '❌ You do not have permission to restore raids. Ask your server admin to configure raid leader roles.',
     });
     return;
   }
 
-  const playerStats = await calculatePlayerStats(player.id, interaction.guild.id, period);
-  const roleDistribution = await getPlayerRoleDistribution(player.id, interaction.guild.id);
-  const history = await getPlayerAttendanceHistory(player.id, interaction.guild.id, period);
+  const raidId = interaction.options.get('raid_id', true).value as string;
 
-  const embed = formatAttendanceEmbed(player.displayName, playerStats, roleDistribution, history, period, guildData.language || 'en');
-
-  await interaction.editReply({ embeds: [embed] });
+  try {
+    await unarchiveRaid(raidId, interaction.guild!.id, interaction.client);
+    await interaction.editReply({
+      content: '✅ Raid restored successfully.',
+    });
+  } catch (error) {
+    console.error('Error restoring raid:', error);
+    await interaction.editReply({
+      content: '❌ Failed to restore raid.',
+    });
+  }
 }
 
 function getStartDate(period: string): Date {
@@ -1610,7 +1512,7 @@ function getStartDate(period: string): Date {
   }
 }
 
-async function handleRaidSuggest(interaction: ChatInputCommandInteraction) {
+async function handleSearchArchive(interaction: ChatInputCommandInteraction) {
   if (!interaction.guild) {
     await interaction.reply({
       content: '❌ This command can only be used in a server!',
@@ -1621,37 +1523,22 @@ async function handleRaidSuggest(interaction: ChatInputCommandInteraction) {
 
   await interaction.deferReply({ ephemeral: true });
 
-  const raidId = interaction.options.get('raid_id', true).value as string;
-
-  const raid = await prisma.raid.findUnique({
-    where: { id: raidId },
-    include: { attendance: true, guild: true },
-  });
-
-  if (!raid) {
-    await interaction.editReply({
-      content: '❌ Raid not found.',
-    });
-    return;
-  }
-
-  if (raid.guildId !== interaction.guild.id) {
-    await interaction.editReply({
-      content: '❌ This raid does not belong to this server.',
-    });
-    return;
-  }
-
-  const composition = await analyzeRaidComposition(raid.attendance);
-  const gaps = findCompositionGaps(raid.attendance);
-  const suggestions = suggestPlayerSwaps(raid.attendance, gaps);
-  const likelihood = calculateSuccessLikelihood(raid.attendance);
+  const query = interaction.options.get('query', true).value as string;
+  const period = interaction.options.get('period', false)?.value as string || 'month';
 
   const guildData = await prisma.guild.findUnique({
     where: { id: interaction.guild.id },
   });
 
-  const embed = formatCompositionEmbed(raid.description || 'Raid', composition, gaps, suggestions, likelihood, guildData?.language || 'en');
+  const startDate = getStartDate(period);
+
+  const results = await searchArchive({
+    guildId: interaction.guild.id,
+    query,
+    startDate,
+  });
+
+  const embed = formatArchiveSearchEmbed(results, query, period, guildData?.language || 'en');
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,6 +2,7 @@ import {
   SlashCommandBuilder,
   CommandInteraction,
   ChatInputCommandInteraction,
+  PermissionFlagsBits,
 } from 'discord.js';
 import prisma from '../database/client';
 import { Command } from '../types';
@@ -81,7 +82,8 @@ const command: Command = {
             .setDescription('The raid to analyze')
             .setRequired(true)
         )
-    ) as SlashCommandBuilder,
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents) as SlashCommandBuilder,
 
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,7 +2,6 @@ import {
   SlashCommandBuilder,
   CommandInteraction,
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
 } from 'discord.js';
 import prisma from '../database/client';
 import { Command } from '../types';
@@ -11,18 +10,13 @@ import { formatRaidStatsEmbed, formatGuildStatsEmbed } from '../utils/statsForma
 import { formatStatusEmbed } from '../utils/statusFormatter';
 import { calculatePlayerStats, getPlayerRoleDistribution, getPlayerAttendanceHistory } from '../utils/attendanceAnalytics';
 import { formatAttendanceEmbed } from '../utils/attendanceFormatter';
-import { analyzeRaidComposition, findCompositionGaps, suggestPlayerSwaps, calculateSuccessLikelihood, CompositionAttendee } from '../utils/compositionAnalyzer';
+import { analyzeRaidComposition, findCompositionGaps, suggestPlayerSwaps, calculateSuccessLikelihood } from '../utils/compositionAnalyzer';
 import { formatCompositionEmbed } from '../utils/compositionFormatter';
-import { formatRaidNotesEmbed } from '../utils/notesFormatter';
-import { archiveRaid, unarchiveRaid, searchArchive } from '../utils/archiveManager';
-import { formatArchiveSearchEmbed } from '../utils/archiveFormatter';
-import { canManageRaids } from '../utils/permissions';
-import { getTranslations } from '../utils/localization';
 
 const command: Command = {
   data: new SlashCommandBuilder()
     .setName('stats')
-    .setDescription('Manage raid statistics, attendance, and archives')
+    .setDescription('View raid statistics, attendance, and composition analysis')
     .addSubcommand((subcommand) =>
       subcommand
         .setName('raid')
@@ -87,79 +81,12 @@ const command: Command = {
             .setDescription('The raid to analyze')
             .setRequired(true)
         )
-    )
-    .addSubcommand((subcommand) =>
-      subcommand
-        .setName('notes')
-        .setDescription('View raid notes and opt-out reasons')
-        .addStringOption((option) =>
-          option
-            .setName('raid_id')
-            .setDescription('The ID of the raid')
-            .setRequired(true)
-        )
-    )
-    .addSubcommand((subcommand) =>
-      subcommand
-        .setName('archive')
-        .setDescription('Archive a raid to keep history clean')
-        .addStringOption((option) =>
-          option
-            .setName('raid_id')
-            .setDescription('The raid to archive')
-            .setRequired(true)
-        )
-    )
-    .addSubcommand((subcommand) =>
-      subcommand
-        .setName('unarchive')
-        .setDescription('Restore an archived raid')
-        .addStringOption((option) =>
-          option
-            .setName('raid_id')
-            .setDescription('The raid to restore')
-            .setRequired(true)
-        )
-    )
-    .addSubcommand((subcommand) =>
-      subcommand
-        .setName('search')
-        .setDescription('Search archived raids')
-        .addStringOption((option) =>
-          option
-            .setName('query')
-            .setDescription('Search query (raid name, player, date)')
-            .setRequired(true)
-        )
-        .addStringOption((option) =>
-          option
-            .setName('period')
-            .setDescription('Time period to search')
-            .addChoices(
-              { name: 'Last 30 days', value: 'month' },
-              { name: 'Last 90 days', value: 'quarter' },
-              { name: 'All time', value: 'all' }
-            )
-            .setRequired(false)
-        )
-     ),
+    ) as SlashCommandBuilder,
 
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
     const subcommand = interaction.options.getSubcommand();
-
-    // Check permissions for leader-only subcommands
-    const isLeaderOnly = ['archive', 'unarchive'].includes(subcommand);
-    if (isLeaderOnly) {
-      if (!(await canManageRaids(interaction.member as any))) {
-        await interaction.reply({
-          content: 'You do not have permission to use this subcommand.',
-          ephemeral: true,
-        });
-        return;
-      }
-    }
 
     if (subcommand === 'raid') {
       await handleRaidStats(interaction);
@@ -171,14 +98,6 @@ const command: Command = {
       await handleAttendanceCommand(interaction);
     } else if (subcommand === 'suggest') {
       await handleSuggestCommand(interaction);
-    } else if (subcommand === 'notes') {
-      await handleNotesCommand(interaction);
-    } else if (subcommand === 'archive') {
-      await handleArchiveCommand(interaction);
-    } else if (subcommand === 'unarchive') {
-      await handleUnarchiveCommand(interaction);
-    } else if (subcommand === 'search') {
-      await handleSearchCommand(interaction);
     }
   },
 };
@@ -391,162 +310,6 @@ async function handleSuggestCommand(interaction: ChatInputCommandInteraction) {
   });
 
   const embed = formatCompositionEmbed(raid.description || 'Raid', composition, gaps, suggestions, likelihood, guildData?.language || 'en');
-
-  await interaction.editReply({ embeds: [embed] });
-}
-
-async function handleNotesCommand(interaction: ChatInputCommandInteraction) {
-  if (!interaction.guild) {
-    await interaction.reply({
-      content: '❌ This command can only be used in a server!',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  await interaction.deferReply({ ephemeral: true });
-
-  const raidId = interaction.options.get('raid_id', true).value as string;
-
-  const raid = await prisma.raid.findUnique({
-    where: { id: raidId },
-    include: { attendance: true, guild: true },
-  });
-
-  if (!raid) {
-    await interaction.editReply({
-      content: '❌ Raid not found.',
-    });
-    return;
-  }
-
-  if (raid.guildId !== interaction.guild.id) {
-    await interaction.editReply({
-      content: '❌ This raid does not belong to this server.',
-    });
-    return;
-  }
-
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
-  const noteEntries: Array<{
-    username: string;
-    playerNote?: string;
-    optoutReason?: string;
-    status: string;
-    notedAt?: Date;
-  }> = raid.attendance.map(att => ({
-    username: att.username,
-    playerNote: att.playerNote || undefined,
-    optoutReason: att.optoutReason || undefined,
-    status: att.status,
-    notedAt: att.notedAt || undefined,
-  }));
-
-  const embed = formatRaidNotesEmbed(raid.description || 'Raid', raid.raidDate, noteEntries, guildData?.language || 'en');
-
-  await interaction.editReply({ embeds: [embed] });
-}
-
-async function handleArchiveCommand(interaction: ChatInputCommandInteraction) {
-  if (!interaction.guild) {
-    await interaction.reply({
-      content: '❌ This command can only be used in a server!',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  await interaction.deferReply({ ephemeral: true });
-
-  // Check permissions
-  const member = interaction.member;
-  if (!member || !(await canManageRaids(member as any))) {
-    await interaction.editReply({
-      content: '❌ You do not have permission to archive raids. Ask your server admin to configure raid leader roles.',
-    });
-    return;
-  }
-
-  const raidId = interaction.options.get('raid_id', true).value as string;
-
-  try {
-    await archiveRaid(raidId, interaction.guild!.id, interaction.client);
-    await interaction.editReply({
-      content: '✅ Raid archived successfully.',
-    });
-  } catch (error) {
-    console.error('Error archiving raid:', error);
-    await interaction.editReply({
-      content: '❌ Failed to archive raid.',
-    });
-  }
-}
-
-async function handleUnarchiveCommand(interaction: ChatInputCommandInteraction) {
-  if (!interaction.guild) {
-    await interaction.reply({
-      content: '❌ This command can only be used in a server!',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  await interaction.deferReply({ ephemeral: true });
-
-  // Check permissions
-  const member = interaction.member;
-  if (!member || !(await canManageRaids(member as any))) {
-    await interaction.editReply({
-      content: '❌ You do not have permission to restore raids. Ask your server admin to configure raid leader roles.',
-    });
-    return;
-  }
-
-  const raidId = interaction.options.get('raid_id', true).value as string;
-
-  try {
-    await unarchiveRaid(raidId, interaction.guild!.id, interaction.client);
-    await interaction.editReply({
-      content: '✅ Raid restored successfully.',
-    });
-  } catch (error) {
-    console.error('Error restoring raid:', error);
-    await interaction.editReply({
-      content: '❌ Failed to restore raid.',
-    });
-  }
-}
-
-async function handleSearchCommand(interaction: ChatInputCommandInteraction) {
-  if (!interaction.guild) {
-    await interaction.reply({
-      content: '❌ This command can only be used in a server!',
-      ephemeral: true,
-    });
-    return;
-  }
-
-  await interaction.deferReply({ ephemeral: true });
-
-  const query = interaction.options.get('query', true).value as string;
-  const period = interaction.options.get('period', false)?.value as string || 'month';
-
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
-  const startDate = getStartDate(period);
-
-  const results = await searchArchive({
-    guildId: interaction.guild.id,
-    query,
-    startDate,
-  });
-
-  const embed = formatArchiveSearchEmbed(results, query, period, guildData?.language || 'en');
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -3,6 +3,7 @@ import { config } from 'dotenv';
 import raidCommand from './commands/raid';
 import configCommand from './commands/config';
 import setupCommand from './commands/setup';
+import statsCommand from './commands/stats';
 
 config();
 
@@ -10,6 +11,7 @@ const commands = [
   raidCommand.data.toJSON(),
   configCommand.data.toJSON(),
   setupCommand.data.toJSON(),
+  statsCommand.data.toJSON(),
 ];
 
 const rest = new REST().setToken(process.env.DISCORD_TOKEN!);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,11 @@ client.commands = new Collection<string, Command>();
 import raidCommand from './commands/raid';
 import configCommand from './commands/config';
 import setupCommand from './commands/setup';
+import statsCommand from './commands/stats';
 client.commands.set(raidCommand.data.name, raidCommand);
 client.commands.set(configCommand.data.name, configCommand);
 client.commands.set(setupCommand.data.name, setupCommand);
+client.commands.set(statsCommand.data.name, statsCommand);
 
 // Ready event
 client.once(Events.ClientReady, async (c) => {


### PR DESCRIPTION
## Summary

- **Move analytics to `/stats`**: `raid`, `guild`, `status`, `attendance`, `suggest` subcommands now live under `/stats` (5 subcommands), registered in both `index.ts` and `deploy-commands.ts`
- **Move archiving to `/raid`**: `archive`, `unarchive`, `search` subcommands now live under `/raid` (13 subcommands total)
- **Remove `notes`**: Dead feature removed entirely per product decision
- **Clean up raid.ts**: Remove ~350 lines of analytics handler code and unused imports
- **Fix stale reference**: `config.ts` message updated from `/stats archive` → `/raid archive`
- **Update feature manifest**: Accurate subcommand counts, `command_prefix` fields for `/stats` features, `archive-system` marked live

## Command structure after this PR

| Command | Subcommands | Purpose |
|---------|-------------|---------|
| `/raid` (13) | create, list, delete, close, open, cancel, remind, refresh, edit, clone, archive, unarchive, search | Raid lifecycle + archiving |
| `/stats` (5) | raid, guild, status, attendance, suggest | Analytics + dashboards |
| `/config` (6) | view, leader-roles, timezone, language, archive-channel, auto-archive | Server configuration |
| `/setup` (0) | — | Setup wizard |

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Deploy commands to a test guild and verify `/stats` appears in Discord
- [ ] Verify `/raid archive`, `/raid unarchive`, `/raid search` work
- [ ] Verify `/stats raid`, `/stats guild`, `/stats status`, `/stats attendance`, `/stats suggest` work
- [ ] Confirm `/raid stats`, `/raid status`, `/raid attendance`, `/raid suggest` no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)