### PR TITLE
feat: two-tier model (Free/Premium) + multi-team support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,4 @@ POSTGRES_PASSWORD=change_me_to_a_strong_password
 
 # Premium / Monetization
 # DISCORD_SKU_PREMIUM: SKU ID for the Premium tier (from Discord Developer Portal > Monetization)
-# DISCORD_SKU_PRO: SKU ID for the Pro tier (from Discord Developer Portal > Monetization)
 # DISCORD_SKU_PREMIUM=your_premium_sku_id
-# DISCORD_SKU_PRO=your_pro_sku_id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Multi-Team support (Premium) — servers can run several raid teams side by side via `/team create|list|delete`; raids, rosters, and statistics are scoped per team
+- Optional `team:<name>` option with autocomplete on `/raid create|list|clone|search` and `/stats guild|status|attendance`, defaulting to the server's default team
+- Every guild gets a default team ("Main") on onboarding; existing guilds, raids, and attendance records are backfilled by migration
+- `team.multi` feature key with upsell embed — free servers keep exactly one team, Premium is unlimited
+
+### Changed
+- PRO tier removed (two-tier model) — only `FREE` and `PREMIUM` remain; existing PRO guilds are migrated to PREMIUM, and all former PRO-only features are now PREMIUM
+- Free-tier upsell hints unified into a shared footer hint across `/raid`, `/stats`, `/config`, and `/team`
+- Welcome embed and trial callout mention Multi-Team as a Premium feature
+- Weekly free-tier raid limit stays server-wide — additional teams do not grant additional raid slots
+
 ---
 
 ## [0.4.0] - 2026-05-18

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Discord bot for WoW raid attendance management with reverse sign-up.
    npm run build
    ```
 
+## Commands
+
+| Command | Subcommands | Description |
+| --- | --- | --- |
+| `/raid` | `create`, `list`, `edit`, `delete`, `clone`, `close`, `open`, `cancel`, `remind`, `refresh`, `archive`, `unarchive`, `search` | Raid lifecycle and archiving |
+| `/team` | `create`, `list`, `delete` | Manage raid teams — one team per server on the free tier, unlimited with Premium |
+| `/stats` | `raid`, `guild`, `status`, `attendance`, `suggest` | Statistics and analytics |
+| `/config` | `view`, `leader-roles`, `timezone`, `language`, `archive-channel`, `auto-archive` | Server configuration |
+| `/setup` | – | Interactive server setup wizard |
+
+Every server starts with one default team. Commands that span multiple raids
+(`/raid create|list|clone|search`, `/stats guild|status|attendance`) take an optional
+`team:<name>` option and fall back to the default team when it is omitted.
+
 ## Documentation
 
 For detailed usage instructions and command references:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Future development plans for RaidPresence.
 
 **Status:** Complete ✅ (shipped in v0.4.0 + follow-ups)
 
-Tiered entitlement system (FREE / PREMIUM / PRO) with feature gating, weekly
+Tiered entitlement system (FREE / PREMIUM) with feature gating, weekly
 limits, and Discord/Stripe-agnostic subscription sync.
 
 - [x] **1.2 — Prisma schema** — `premiumTier`, `premiumExpiresAt`, `entitlementId`, `weeklyRaidCount`, `weeklyRaidCountResetAt`, `trialStartedAt` on `Guild`
@@ -93,7 +93,7 @@ limits, and Discord/Stripe-agnostic subscription sync.
   - Generic raid/event system
   - Game-specific customization
 
-- [ ] **Custom Raid Templates** (`raid.template`, PRO)
+- [ ] **Custom Raid Templates** (`raid.template`, PREMIUM)
   - Save raid configurations as templates
   - Quick-create from templates
   - Share templates with other servers

--- a/docs/feature-manifest.json
+++ b/docs/feature-manifest.json
@@ -29,7 +29,7 @@
       "category": "commands",
       "status": "live",
       "premium_tier": "FREE",
-      "premium_note": "Free tier limited to 5 raid creates per week; PREMIUM/PRO unlimited",
+      "premium_note": "Free tier limited to 5 raid creates per week; PREMIUM unlimited",
       "summary": "Create, edit, clone, close, cancel, and delete raids with a single command.",
       "landing_copy": "Complete raid management from creation to archive — one command handles it all.",
       "docs_url": "docs/commands/RAID-COMMAND.md",

--- a/docs/feature-manifest.json
+++ b/docs/feature-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.4.0",
-  "updated_at": "2026-05-18",
+  "updated_at": "2026-07-27",
   "tagline": "Discord bot for WoW raid attendance management with reverse sign-up",
   "description": "RaidPresence uses a reverse sign-up system where all eligible guild members are automatically signed up for raids and must opt-out if they cannot attend — reducing friction and improving attendance visibility.",
   "supported_languages": ["en", "de"],
@@ -35,6 +35,20 @@
       "docs_url": "docs/commands/RAID-COMMAND.md",
       "commands": ["create", "edit", "clone", "close", "cancel", "delete"],
       "since": "0.0.1"
+    },
+    {
+      "id": "multi-team",
+      "name": "Multiple Raid Teams",
+      "category": "commands",
+      "status": "live",
+      "premium_tier": "FREE",
+      "premium_note": "Free tier limited to 1 team; PREMIUM unlimited",
+      "summary": "Split a server into several raid teams — each raid, roster, and statistic is scoped to its team, so a guild can run mains and alts side by side.",
+      "landing_copy": "Mains on Tuesday, alts on Friday. Give every roster its own team — raids and stats stay neatly separated.",
+      "docs_url": "docs/commands/CONFIG-COMMAND.md",
+      "commands": ["create", "list", "delete"],
+      "command_prefix": "/team",
+      "since": "0.5.0"
     },
     {
       "id": "attendance-tracking",
@@ -184,6 +198,13 @@
       "description": "Statistics and analytics — raid, guild, status, attendance, suggest",
       "status": "live",
       "docs_url": "docs/commands/RAID-COMMAND.md"
+    },
+    {
+      "name": "/team",
+      "subcommand_count": 3,
+      "description": "Raid team management — create, list, delete",
+      "status": "live",
+      "docs_url": "docs/commands/CONFIG-COMMAND.md"
     },
     {
       "name": "/config",
@@ -436,6 +457,87 @@
         "The status dashboard only shows open raids with future dates — closed or past raids are excluded.",
         "Attendance data is based on final roster state — opt-outs that later re-join are counted as attending.",
         "Suggest works best when raids have a roles composition set (e.g., '2T 4H 14D' on creation)."
+      ]
+    },
+    {
+      "id": "team",
+      "name": "/team",
+      "path": "/docs/team",
+      "summary": "Raid team management — create, list, delete",
+      "highlights": [
+        "3 subcommands available",
+        "Every server starts with one default team",
+        "Raids, rosters, and stats are scoped per team",
+        "Additional teams require Premium"
+      ],
+      "syntax": "/team <subcommand> [options]",
+      "parameters": [
+        {
+          "name": "create",
+          "required": false,
+          "format": "name:<text>",
+          "description": "Create an additional raid team (max 50 characters) — Premium only, the free tier keeps its single default team"
+        },
+        {
+          "name": "list",
+          "required": false,
+          "format": "(no options)",
+          "description": "List all teams of this server with their raid counts and a badge on the default team"
+        },
+        {
+          "name": "delete",
+          "required": false,
+          "format": "name:<text>",
+          "description": "Delete a team and all of its raids — the default team cannot be deleted"
+        }
+      ],
+      "examples": [
+        {
+          "title": "Create an alt team",
+          "command": "/team create name:Alts",
+          "description": "Adds a second team next to the default team (requires Premium)"
+        },
+        {
+          "title": "Create a raid for a specific team",
+          "command": "/raid create team:Alts date:2026-08-07 time:20:00 title:Alt Run roles:Member",
+          "description": "Creates the raid inside the Alts team instead of the default team"
+        },
+        {
+          "title": "Team-scoped statistics",
+          "command": "/stats guild team:Alts period:month",
+          "description": "Aggregates only the raids of the Alts team for the last 30 days"
+        }
+      ],
+      "sections": [
+        {
+          "title": "Team Scoping",
+          "body": "Commands that work on more than one raid accept an optional team option and fall back to the default team when it is omitted.",
+          "bullets": [
+            "/raid create, /raid list, /raid clone, /raid search",
+            "/stats guild, /stats status, /stats attendance",
+            "Subcommands that take a raid_id need no team option — the ID already pins the team",
+            "The weekly free-tier raid limit is counted server-wide, not per team"
+          ]
+        },
+        {
+          "title": "Tier Behavior",
+          "body": "Every server gets one default team for free; more teams are a Premium feature.",
+          "bullets": [
+            "Free — exactly one team (the default 'Main' team, created automatically)",
+            "Premium — unlimited teams",
+            "Existing teams stay readable after Premium expires; only creating further teams is blocked again",
+            "Deleting a team also deletes its raids and attendance records"
+          ]
+        }
+      ],
+      "permissions": [
+        "Administrator permission required"
+      ],
+      "troubleshooting": [
+        "If /team create replies with an upgrade embed, the server is on the free tier and already has its one team.",
+        "The default team cannot be deleted — it is the fallback for every command used without a team option.",
+        "Team names are matched case-insensitively, but must be unique per server.",
+        "If a raid does not show up in /raid list, check whether it belongs to another team."
       ]
     },
     {

--- a/prisma/migrations/20260727000000_remove_pro_tier/migration.sql
+++ b/prisma/migrations/20260727000000_remove_pro_tier/migration.sql
@@ -1,11 +1,37 @@
+-- Rerunnable: every step is guarded on "PremiumTier still has a 'PRO' value", so applying
+-- this migration to an already-migrated database is a no-op instead of an error.
+-- Order is preserved: the data migration runs before the type swap.
+
 -- MigrateData: existing PRO guilds keep their perks and become PREMIUM
-UPDATE "Guild" SET "premiumTier" = 'PREMIUM' WHERE "premiumTier" = 'PRO';
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'PremiumTier' AND e.enumlabel = 'PRO'
+  ) THEN
+    UPDATE "Guild" SET "premiumTier" = 'PREMIUM' WHERE "premiumTier"::text = 'PRO';
+  END IF;
+END $$;
 
 -- AlterEnum: Postgres cannot drop an enum value, so swap in a new type
-CREATE TYPE "PremiumTier_new" AS ENUM ('FREE', 'PREMIUM');
-ALTER TABLE "Guild" ALTER COLUMN "premiumTier" DROP DEFAULT;
-ALTER TABLE "Guild" ALTER COLUMN "premiumTier" TYPE "PremiumTier_new" USING ("premiumTier"::text::"PremiumTier_new");
-ALTER TYPE "PremiumTier" RENAME TO "PremiumTier_old";
-ALTER TYPE "PremiumTier_new" RENAME TO "PremiumTier";
-DROP TYPE "PremiumTier_old";
-ALTER TABLE "Guild" ALTER COLUMN "premiumTier" SET DEFAULT 'FREE';
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'PremiumTier' AND e.enumlabel = 'PRO'
+  ) THEN
+    -- Clean up a scratch type left behind by a previously aborted run.
+    DROP TYPE IF EXISTS "PremiumTier_new";
+
+    CREATE TYPE "PremiumTier_new" AS ENUM ('FREE', 'PREMIUM');
+    ALTER TABLE "Guild" ALTER COLUMN "premiumTier" DROP DEFAULT;
+    ALTER TABLE "Guild" ALTER COLUMN "premiumTier" TYPE "PremiumTier_new"
+      USING ("premiumTier"::text::"PremiumTier_new");
+    ALTER TYPE "PremiumTier" RENAME TO "PremiumTier_old";
+    ALTER TYPE "PremiumTier_new" RENAME TO "PremiumTier";
+    DROP TYPE "PremiumTier_old";
+    ALTER TABLE "Guild" ALTER COLUMN "premiumTier" SET DEFAULT 'FREE';
+  END IF;
+END $$;

--- a/prisma/migrations/20260727000000_remove_pro_tier/migration.sql
+++ b/prisma/migrations/20260727000000_remove_pro_tier/migration.sql
@@ -1,0 +1,11 @@
+-- MigrateData: existing PRO guilds keep their perks and become PREMIUM
+UPDATE "Guild" SET "premiumTier" = 'PREMIUM' WHERE "premiumTier" = 'PRO';
+
+-- AlterEnum: Postgres cannot drop an enum value, so swap in a new type
+CREATE TYPE "PremiumTier_new" AS ENUM ('FREE', 'PREMIUM');
+ALTER TABLE "Guild" ALTER COLUMN "premiumTier" DROP DEFAULT;
+ALTER TABLE "Guild" ALTER COLUMN "premiumTier" TYPE "PremiumTier_new" USING ("premiumTier"::text::"PremiumTier_new");
+ALTER TYPE "PremiumTier" RENAME TO "PremiumTier_old";
+ALTER TYPE "PremiumTier_new" RENAME TO "PremiumTier";
+DROP TYPE "PremiumTier_old";
+ALTER TABLE "Guild" ALTER COLUMN "premiumTier" SET DEFAULT 'FREE';

--- a/prisma/migrations/20260727010000_add_teams/migration.sql
+++ b/prisma/migrations/20260727010000_add_teams/migration.sql
@@ -1,5 +1,9 @@
+-- Rerunnable: DDL uses IF NOT EXISTS (constraints, which have no such clause, are guarded
+-- against pg_constraint) and the backfills only touch rows that are still unmigrated.
+-- Order is preserved: data is backfilled before the columns become NOT NULL.
+
 -- CreateTable
-CREATE TABLE "Team" (
+CREATE TABLE IF NOT EXISTS "Team" (
     "id" TEXT NOT NULL,
     "guildId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -12,46 +16,61 @@ CREATE TABLE "Team" (
 );
 
 -- CreateIndex
-CREATE INDEX "Team_guildId_idx" ON "Team"("guildId");
+CREATE INDEX IF NOT EXISTS "Team_guildId_idx" ON "Team"("guildId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Team_guildId_name_key" ON "Team"("guildId", "name");
+CREATE UNIQUE INDEX IF NOT EXISTS "Team_guildId_name_key" ON "Team"("guildId", "name");
 
 -- AddForeignKey
-ALTER TABLE "Team" ADD CONSTRAINT "Team_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Team_guildId_fkey') THEN
+    ALTER TABLE "Team" ADD CONSTRAINT "Team_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
 
--- MigrateData: every existing guild gets exactly one default team ("Main")
+-- MigrateData: every existing guild gets exactly one default team ("Main").
+-- Guilds that already have a default team are skipped, so a rerun adds nothing.
 INSERT INTO "Team" ("id", "guildId", "name", "isDefault", "createdBy", "createdAt", "updatedAt")
 SELECT md5(random()::text || g."id"), g."id", 'Main', true, 'system', NOW(), NOW()
-FROM "Guild" g;
+FROM "Guild" g
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Team" t WHERE t."guildId" = g."id" AND t."isDefault" = true
+);
 
 -- AlterTable: add team references as nullable first so the backfill can run
-ALTER TABLE "Raid" ADD COLUMN "teamId" TEXT;
-ALTER TABLE "RaidAttendance" ADD COLUMN "teamId" TEXT;
+ALTER TABLE "Raid" ADD COLUMN IF NOT EXISTS "teamId" TEXT;
+ALTER TABLE "RaidAttendance" ADD COLUMN IF NOT EXISTS "teamId" TEXT;
 
 -- MigrateData: point existing raids at their guild's default team
 UPDATE "Raid" r SET "teamId" = t."id"
 FROM "Team" t
-WHERE t."guildId" = r."guildId" AND t."isDefault" = true;
+WHERE t."guildId" = r."guildId" AND t."isDefault" = true AND r."teamId" IS NULL;
 
 -- MigrateData: attendance inherits the team of its raid
 UPDATE "RaidAttendance" a SET "teamId" = t."id"
 FROM "Raid" r
 JOIN "Team" t ON t."id" = r."teamId"
-WHERE a."raidId" = r."id";
+WHERE a."raidId" = r."id" AND a."teamId" IS NULL;
 
 -- AlterTable: the backfill is complete, so the column becomes mandatory
+-- (SET NOT NULL is a no-op on an already NOT NULL column)
 ALTER TABLE "Raid" ALTER COLUMN "teamId" SET NOT NULL;
 ALTER TABLE "RaidAttendance" ALTER COLUMN "teamId" SET NOT NULL;
 
 -- AddForeignKey
-ALTER TABLE "Raid" ADD CONSTRAINT "Raid_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Raid_teamId_fkey') THEN
+    ALTER TABLE "Raid" ADD CONSTRAINT "Raid_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
 
 -- CreateIndex
-CREATE INDEX "Raid_teamId_status_idx" ON "Raid"("teamId", "status");
+CREATE INDEX IF NOT EXISTS "Raid_teamId_status_idx" ON "Raid"("teamId", "status");
 
 -- CreateIndex
-CREATE INDEX "Raid_teamId_raidDate_idx" ON "Raid"("teamId", "raidDate");
+CREATE INDEX IF NOT EXISTS "Raid_teamId_raidDate_idx" ON "Raid"("teamId", "raidDate");
 
 -- CreateIndex
-CREATE INDEX "RaidAttendance_teamId_userId_status_idx" ON "RaidAttendance"("teamId", "userId", "status");
+CREATE INDEX IF NOT EXISTS "RaidAttendance_teamId_userId_status_idx" ON "RaidAttendance"("teamId", "userId", "status");

--- a/prisma/migrations/20260727010000_add_teams/migration.sql
+++ b/prisma/migrations/20260727010000_add_teams/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Team_guildId_idx" ON "Team"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_guildId_name_key" ON "Team"("guildId", "name");
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- MigrateData: every existing guild gets exactly one default team ("Main")
+INSERT INTO "Team" ("id", "guildId", "name", "isDefault", "createdBy", "createdAt", "updatedAt")
+SELECT md5(random()::text || g."id"), g."id", 'Main', true, 'system', NOW(), NOW()
+FROM "Guild" g;
+
+-- AlterTable: add team references as nullable first so the backfill can run
+ALTER TABLE "Raid" ADD COLUMN "teamId" TEXT;
+ALTER TABLE "RaidAttendance" ADD COLUMN "teamId" TEXT;
+
+-- MigrateData: point existing raids at their guild's default team
+UPDATE "Raid" r SET "teamId" = t."id"
+FROM "Team" t
+WHERE t."guildId" = r."guildId" AND t."isDefault" = true;
+
+-- MigrateData: attendance inherits the team of its raid
+UPDATE "RaidAttendance" a SET "teamId" = t."id"
+FROM "Raid" r
+JOIN "Team" t ON t."id" = r."teamId"
+WHERE a."raidId" = r."id";
+
+-- AlterTable: the backfill is complete, so the column becomes mandatory
+ALTER TABLE "Raid" ALTER COLUMN "teamId" SET NOT NULL;
+ALTER TABLE "RaidAttendance" ALTER COLUMN "teamId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Raid" ADD CONSTRAINT "Raid_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "Raid_teamId_status_idx" ON "Raid"("teamId", "status");
+
+-- CreateIndex
+CREATE INDEX "Raid_teamId_raidDate_idx" ON "Raid"("teamId", "raidDate");
+
+-- CreateIndex
+CREATE INDEX "RaidAttendance_teamId_userId_status_idx" ON "RaidAttendance"("teamId", "userId", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,6 @@ datasource db {
 enum PremiumTier {
   FREE
   PREMIUM
-  PRO
 }
 
 model Guild {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,17 +98,19 @@ model Raid {
   archiveMessageId String?   // Message ID of archived embed
   isPinned         Boolean   @default(false) // Is raid pinned/archived?
 
-  // Team assignment (RPTIER Phase 2) — nullable until the backfill migration lands
-  teamId String?
+  // Team assignment (RPTIER Phase 2) — backfilled to the guild's default team
+  teamId String
 
   guild      Guild            @relation(fields: [guildId], references: [id], onDelete: Cascade)
-  team       Team?            @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  team       Team             @relation(fields: [teamId], references: [id], onDelete: Cascade)
   attendance RaidAttendance[]
 
   @@index([guildId, status])
   @@index([raidDate])
   @@index([guildId, raidDate])
   @@index([guildId, archivedAt])
+  @@index([teamId, status])
+  @@index([teamId, raidDate])
 }
 
 model UserRolePreference {
@@ -147,7 +149,12 @@ model RaidAttendance {
   userPreference UserPreference? @relation(fields: [userId, guildId], references: [userId, guildId])
   guildId        String
 
+  // Denormalized team assignment (RPTIER Phase 2) — inherited from the raid, kept
+  // relation-free on purpose so cascades stay driven by Raid alone
+  teamId String
+
   @@unique([raidId, userId])
   @@index([raidId, status])
   @@index([userId, guildId, status])
+  @@index([teamId, userId, status])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,23 @@ model Guild {
   raids Raid[]
   users UserPreference[]
   rolePreferences UserRolePreference[]
+  teams Team[]
+}
+
+model Team {
+  id        String   @id @default(cuid())
+  guildId   String
+  name      String
+  isDefault Boolean  @default(false) // Exactly one default ("Main") team per guild
+  createdBy String // Discord user ID of the creator ("system" for auto-created default teams)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  guild Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  raids Raid[]
+
+  @@unique([guildId, name])
+  @@index([guildId])
 }
 
 model UserPreference {
@@ -81,7 +98,11 @@ model Raid {
   archiveMessageId String?   // Message ID of archived embed
   isPinned         Boolean   @default(false) // Is raid pinned/archived?
 
+  // Team assignment (RPTIER Phase 2) — nullable until the backfill migration lands
+  teamId String?
+
   guild      Guild            @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  team       Team?            @relation(fields: [teamId], references: [id], onDelete: Cascade)
   attendance RaidAttendance[]
 
   @@index([guildId, status])

--- a/src/__tests__/entitlementService.test.ts
+++ b/src/__tests__/entitlementService.test.ts
@@ -5,6 +5,7 @@ import {
   getTier,
   syncEntitlement,
   hasFeature,
+  FEATURE_TIERS,
   tryConsumeWeeklyRaid,
   grantTrialIfEligible,
   TRIAL_DAYS,
@@ -34,7 +35,7 @@ describe('getTier()', () => {
 
   it('returns FREE when subscription expired', async () => {
     (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
-      premiumTier: 'PRO',
+      premiumTier: 'PREMIUM',
       premiumExpiresAt: new Date('2020-01-01'),
     } as any);
     expect(await getTier('guild1')).toBe('FREE');
@@ -95,30 +96,18 @@ describe('syncEntitlement()', () => {
 });
 
 describe('hasFeature()', () => {
-  const premiumFeatures: PremiumFeature[] = ['raid.optout_reason', 'raid.archive', 'raid.recurring', 'stats.full_history', 'stats.analytics'];
-  const proFeatures: PremiumFeature[] = ['raid.template', 'stats.export', 'raid.integrations'];
+  const allFeatures = Object.keys(FEATURE_TIERS) as PremiumFeature[];
 
   it('FREE tier has no gated features', () => {
-    for (const feature of [...premiumFeatures, ...proFeatures]) {
+    for (const feature of allFeatures) {
       expect(hasFeature('FREE', feature)).toBe(false);
     }
   });
 
-  it('PREMIUM tier has premium features', () => {
-    for (const feature of premiumFeatures) {
+  // Two-tier model: PREMIUM is the top tier, so it unlocks everything in FEATURE_TIERS.
+  it('PREMIUM tier has every gated feature', () => {
+    for (const feature of allFeatures) {
       expect(hasFeature('PREMIUM', feature)).toBe(true);
-    }
-  });
-
-  it('PREMIUM tier does not have PRO features', () => {
-    for (const feature of proFeatures) {
-      expect(hasFeature('PREMIUM', feature)).toBe(false);
-    }
-  });
-
-  it('PRO tier has all features', () => {
-    for (const feature of [...premiumFeatures, ...proFeatures]) {
-      expect(hasFeature('PRO', feature)).toBe(true);
     }
   });
 });
@@ -141,18 +130,6 @@ describe('tryConsumeWeeklyRaid()', () => {
     const result = await tryConsumeWeeklyRaid('guild1');
     expect(result).toEqual(expect.objectContaining({ allowed: true, remaining: Infinity }));
     expect((prisma.guild.update as jest.Mock)).not.toHaveBeenCalled();
-  });
-
-  it('returns unlimited for PRO tier', async () => {
-    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
-      premiumTier: 'PRO',
-      premiumExpiresAt: null,
-      weeklyRaidCount: 99,
-      weeklyRaidCountResetAt: new Date(),
-    } as any);
-
-    const result = await tryConsumeWeeklyRaid('guild1');
-    expect(result).toEqual(expect.objectContaining({ allowed: true, remaining: Infinity }));
   });
 
   it('consumes a slot and returns remaining for FREE tier', async () => {
@@ -294,11 +271,11 @@ describe('grantTrialIfEligible()', () => {
 
   it('reports the current paid tier when the conditional grant matched nothing', async () => {
     (prisma.guild.updateMany as jest.Mock).mockResolvedValue({ count: 0 } as any);
-    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ premiumTier: 'PRO' } as any);
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ premiumTier: 'PREMIUM' } as any);
 
     const result = await grantTrialIfEligible('guild1');
     expect(result.granted).toBe(false);
-    expect(result.tier).toBe('PRO');
+    expect(result.tier).toBe('PREMIUM');
   });
 
   it('does not grant for an unknown guild', async () => {

--- a/src/__tests__/integration/multiTeam.integration.test.ts
+++ b/src/__tests__/integration/multiTeam.integration.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Multi-Team Lifecycle Integration Test (RPTIER Phase 6)
+ *
+ * Walks one guild through the whole two-tier multi-team story, in order, against a
+ * single mutable in-memory store:
+ *   1. onboarding                → the default "Main" team is provisioned
+ *   2. FREE hits the team gate   → no team is written, an ephemeral upsell goes out
+ *   3. trial grant               → the guild becomes PREMIUM
+ *   4. PREMIUM creates team B    → `/team create` succeeds
+ *   5. raids in A and B          → each raid carries its own teamId
+ *   6. `stats guild` for team A  → team B's raid is not aggregated
+ *   7. premium expires           → existing teams and raids stay intact and readable,
+ *                                  but a further team is blocked again
+ *
+ * Step 7 is the important one: a downgrade must never delete or hide data.
+ *
+ * Unlike the sibling command suites, neither `entitlementService` nor `premiumGate` is
+ * mocked here — the real tier lookup, the real `canCreateAdditionalTeam` and the real
+ * `gateFeature` run against the store, so the upsell embed and the downgrade behaviour
+ * are observed rather than stubbed. Only `permissions` is mocked (Discord role checks).
+ *
+ * The `it` blocks share state deliberately and must run in file order; each step builds
+ * on the state the previous one left behind.
+ */
+
+import { Prisma } from '@prisma/client';
+
+jest.mock('../../database/client');
+jest.mock('../../utils/permissions');
+
+import prisma from '../../database/client';
+import { canManageRaids } from '../../utils/permissions';
+import {
+  clearTierCache,
+  getTier,
+  grantTrialIfEligible,
+  TRIAL_DAYS,
+} from '../../services/entitlementService';
+import { getDefaultTeam, DEFAULT_TEAM_NAME } from '../../services/teamService';
+import teamCommand from '../../commands/team';
+import raidCommand from '../../commands/raid';
+import statsCommand from '../../commands/stats';
+
+const GUILD_ID = 'guild-multi-team';
+const ADMIN_ID = 'user-admin';
+
+// ─── In-memory store ──────────────────────────────────────────────
+
+interface TeamRow {
+  id: string;
+  guildId: string;
+  name: string;
+  isDefault: boolean;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const db = {
+  guild: {
+    id: GUILD_ID,
+    name: 'Multi Team Guild',
+    language: 'en',
+    timezoneOffset: 0,
+    raidRoles: 'role-raider',
+    raidLeaderRoles: 'role-leader',
+    premiumTier: 'FREE',
+    premiumExpiresAt: null as Date | null,
+    entitlementId: null as string | null,
+    trialStartedAt: null as Date | null,
+    weeklyRaidCount: 0,
+    weeklyRaidCountResetAt: null as Date | null,
+  } as Record<string, any>,
+  teams: [] as TeamRow[],
+  raids: [] as Array<Record<string, any>>,
+  attendance: [] as Array<Record<string, any>>,
+};
+
+let teamSeq = 0;
+let raidSeq = 0;
+
+/** The P2002 Prisma raises when `@@unique([guildId, name])` is violated. */
+function uniqueConstraintError() {
+  return new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '5.22.0',
+    meta: { target: ['guildId', 'name'] },
+  });
+}
+
+function teamByName(guildId: string, name: string): TeamRow | undefined {
+  return db.teams.find(
+    (team) => team.guildId === guildId && team.name.toLowerCase() === name.toLowerCase()
+  );
+}
+
+/** A raid row with its attendance attached, as `include: { attendance: true }` returns it. */
+function hydrateRaid(raid: Record<string, any>) {
+  return {
+    ...raid,
+    attendance: db.attendance.filter((row) => row.raidId === raid.id),
+    guild: db.guild,
+  };
+}
+
+/** Wires every prisma method the exercised code paths touch to the store above. */
+function installStoreMocks() {
+  (prisma.guild.findUnique as jest.Mock).mockImplementation(async ({ where }: any) =>
+    where.id === db.guild.id ? { ...db.guild } : null
+  );
+  (prisma.guild.update as jest.Mock).mockImplementation(async ({ where, data }: any) => {
+    if (where.id !== db.guild.id) throw new Error(`unknown guild ${where.id}`);
+    Object.assign(db.guild, data);
+    return { ...db.guild };
+  });
+  // `grantTrialIfEligible` puts its eligibility predicate into the WHERE clause, so the
+  // mock has to actually evaluate it instead of blindly writing.
+  (prisma.guild.updateMany as jest.Mock).mockImplementation(async ({ where, data }: any) => {
+    const matches = Object.entries(where).every(
+      ([key, value]) => db.guild[key] === value || (value === null && db.guild[key] == null)
+    );
+    if (!matches) return { count: 0 };
+    Object.assign(db.guild, data);
+    return { count: 1 };
+  });
+
+  (prisma.team.findFirst as jest.Mock).mockImplementation(async ({ where }: any) => {
+    if (where.isDefault) {
+      return db.teams.find((team) => team.guildId === where.guildId && team.isDefault) ?? null;
+    }
+    return teamByName(where.guildId, String(where.name?.equals ?? '')) ?? null;
+  });
+  (prisma.team.findUnique as jest.Mock).mockImplementation(
+    async ({ where }: any) => db.teams.find((team) => team.id === where.id) ?? null
+  );
+  (prisma.team.findMany as jest.Mock).mockImplementation(async ({ where }: any) =>
+    db.teams
+      .filter((team) => team.guildId === where.guildId)
+      .sort((a, b) => Number(b.isDefault) - Number(a.isDefault) || a.name.localeCompare(b.name))
+  );
+  (prisma.team.count as jest.Mock).mockImplementation(
+    async ({ where }: any) => db.teams.filter((team) => team.guildId === where.guildId).length
+  );
+  (prisma.team.create as jest.Mock).mockImplementation(async ({ data }: any) => {
+    if (teamByName(data.guildId, data.name)) throw uniqueConstraintError();
+    const now = new Date();
+    const row: TeamRow = { id: `team-${++teamSeq}`, createdAt: now, updatedAt: now, ...data };
+    db.teams.push(row);
+    return row;
+  });
+  (prisma.team.delete as jest.Mock).mockImplementation(async ({ where }: any) => {
+    const index = db.teams.findIndex((team) => team.id === where.id);
+    const [removed] = db.teams.splice(index, 1);
+    // Mirror the schema's cascade so "nothing was deleted" assertions stay meaningful.
+    db.raids = db.raids.filter((raid) => raid.teamId !== where.id);
+    return removed;
+  });
+
+  (prisma.raid.create as jest.Mock).mockImplementation(async ({ data }: any) => {
+    const row = { id: `raid-${++raidSeq}`, status: 'open', ...data };
+    db.raids.push(row);
+    return row;
+  });
+  (prisma.raid.update as jest.Mock).mockImplementation(async ({ where, data }: any) => {
+    const raid = db.raids.find((row) => row.id === where.id);
+    if (raid) Object.assign(raid, data);
+    return raid;
+  });
+  (prisma.raid.findUnique as jest.Mock).mockImplementation(async ({ where }: any) => {
+    const raid = db.raids.find((row) => row.id === where.id);
+    return raid ? hydrateRaid(raid) : null;
+  });
+  (prisma.raid.findMany as jest.Mock).mockImplementation(async ({ where }: any) =>
+    db.raids
+      .filter((raid) => {
+        if (where.guildId && raid.guildId !== where.guildId) return false;
+        if (where.teamId && raid.teamId !== where.teamId) return false;
+        if (where.status && raid.status !== where.status) return false;
+        if (where.raidDate?.gte && raid.raidDate < where.raidDate.gte) return false;
+        return true;
+      })
+      .map(hydrateRaid)
+  );
+  (prisma.raid.count as jest.Mock).mockImplementation(async ({ where }: any) =>
+    db.raids.filter((raid) => !where?.teamId || raid.teamId === where.teamId).length
+  );
+
+  (prisma.raidAttendance.createMany as jest.Mock).mockImplementation(async ({ data }: any) => {
+    const rows = Array.isArray(data) ? data : [data];
+    db.attendance.push(...rows);
+    return { count: rows.length };
+  });
+  (prisma.raidAttendance.findMany as jest.Mock).mockResolvedValue([]);
+  (prisma.userPreference.upsert as jest.Mock).mockResolvedValue({});
+  (prisma.userPreference.findMany as jest.Mock).mockResolvedValue([]);
+  (prisma.userRolePreference.findMany as jest.Mock).mockResolvedValue([]);
+}
+
+// ─── Interaction helpers ──────────────────────────────────────────
+
+/** Minimal Collection-like Map covering the discord.js helpers the handlers use. */
+class MockCollection<K, V> extends Map<K, V> {
+  some(fn: (value: V, key: K, map: this) => boolean): boolean {
+    for (const [key, value] of this) if (fn(value, key, this)) return true;
+    return false;
+  }
+
+  filter(fn: (value: V, key: K, map: this) => boolean): MockCollection<K, V> {
+    const result = new MockCollection<K, V>();
+    for (const [key, value] of this) if (fn(value, key, this)) result.set(key, value);
+    return result;
+  }
+
+  find(fn: (value: V, key: K, map: this) => boolean): V | undefined {
+    for (const [key, value] of this) if (fn(value, key, this)) return value;
+    return undefined;
+  }
+}
+
+function futureDateStr(daysFromNow = 7): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString().split('T')[0];
+}
+
+function baseInteraction() {
+  return {
+    isChatInputCommand: jest.fn().mockReturnValue(true),
+    guildId: GUILD_ID,
+    guild: { id: GUILD_ID, name: db.guild.name },
+    user: { id: ADMIN_ID },
+    member: { user: { bot: false, id: ADMIN_ID }, roles: { cache: new MockCollection() } },
+    channel: { id: 'channel-1' },
+    replied: false,
+    deferred: false,
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+    followUp: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** `/team <subcommand> [name:…]` */
+function buildTeamInteraction(subcommand: string, name?: string) {
+  return {
+    ...baseInteraction(),
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      getString: jest.fn(() => name ?? null),
+    },
+  } as any;
+}
+
+/** `/raid <subcommand> [team:…]` — carries the member/role cache raid create scans. */
+function buildRaidInteraction(subcommand: string, options: Record<string, any> = {}) {
+  const rolesCache = new MockCollection<string, any>();
+  rolesCache.set('role-raider', { id: 'role-raider', name: 'role-raider' });
+
+  const memberRolesCache = new MockCollection<string, any>();
+  memberRolesCache.set('role-raider', { id: 'role-raider', name: 'role-raider' });
+
+  const membersCache = new MockCollection<string, any>();
+  membersCache.set('user-200', {
+    user: { bot: false, id: 'user-200' },
+    roles: { cache: memberRolesCache },
+    displayName: 'TankPlayer',
+  });
+  membersCache.set('user-201', {
+    user: { bot: false, id: 'user-201' },
+    roles: { cache: memberRolesCache },
+    displayName: 'HealerPlayer',
+  });
+
+  return {
+    ...baseInteraction(),
+    guild: {
+      id: GUILD_ID,
+      name: db.guild.name,
+      members: { cache: membersCache, fetch: jest.fn().mockResolvedValue(undefined) },
+      roles: { cache: rolesCache },
+    },
+    member: {
+      user: { bot: false, id: ADMIN_ID },
+      roles: { cache: memberRolesCache },
+      displayName: 'Admin',
+    },
+    channel: {
+      id: 'channel-1',
+      isTextBased: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue({ id: 'message-new' }),
+    },
+    client: {
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          isTextBased: jest.fn().mockReturnValue(true),
+          messages: { fetch: jest.fn() },
+        }),
+      },
+    },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      get: jest.fn((key: string, required?: boolean) =>
+        options[key] !== undefined ? options[key] : required ? { value: null } : undefined
+      ),
+    },
+  } as any;
+}
+
+/** Baseline valid `raid create` options, optionally scoped to a named team. */
+function createOptions(title: string, team?: string) {
+  const options: Record<string, any> = {
+    date: { value: futureDateStr() },
+    time: { value: '20:00' },
+    title: { value: title },
+    roles: { value: 'role-raider' },
+    ping_roles: { value: false },
+  };
+  if (team !== undefined) options.team = { value: team };
+  return options;
+}
+
+/** `/stats <subcommand> [team:…]` */
+function buildStatsInteraction(subcommand: string, options: Record<string, any> = {}) {
+  return {
+    ...baseInteraction(),
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      get: jest.fn((key: string, required?: boolean) =>
+        options[key] || (required ? { value: null } : undefined)
+      ),
+    },
+  } as any;
+}
+
+/** Last reply payload sent through `reply` or `editReply`. */
+function lastReply(interaction: any): any {
+  const calls = [
+    ...interaction.reply.mock.calls,
+    ...interaction.editReply.mock.calls,
+  ];
+  return calls.at(-1)?.[0];
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────
+
+describe('multi-team lifecycle', () => {
+  beforeAll(() => {
+    installStoreMocks();
+    (canManageRaids as jest.Mock).mockResolvedValue(true);
+  });
+
+  beforeEach(() => {
+    clearTierCache();
+  });
+
+  // 1 ── onboarding ───────────────────────────────────────────────
+
+  it('provisions a default team when the guild is onboarded', async () => {
+    const team = await getDefaultTeam(GUILD_ID);
+
+    expect(team).toMatchObject({ guildId: GUILD_ID, name: DEFAULT_TEAM_NAME, isDefault: true });
+    expect(db.teams).toHaveLength(1);
+    expect(await getTier(GUILD_ID)).toBe('FREE');
+  });
+
+  // 2 ── FREE hits the gate ───────────────────────────────────────
+
+  it('blocks a second team on the free tier and answers with an ephemeral upsell', async () => {
+    const interaction = buildTeamInteraction('create', 'Alts');
+
+    await teamCommand.execute(interaction);
+
+    expect(db.teams).toHaveLength(1);
+    expect(prisma.team.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ name: 'Alts' }) })
+    );
+
+    const reply = interaction.reply.mock.calls.at(-1)[0];
+    expect(reply.ephemeral).toBe(true);
+    const embed = reply.embeds[0].data;
+    expect(embed.title).toContain('Multiple Teams');
+    // The perks field sells premium regardless of which feature triggered the gate.
+    expect(embed.fields.some((f: any) => f.name.includes('Premium'))).toBe(true);
+  });
+
+  // 3 ── trial ────────────────────────────────────────────────────
+
+  it('flips the guild to premium when the trial is granted', async () => {
+    const trial = await grantTrialIfEligible(GUILD_ID);
+
+    expect(trial).toMatchObject({ granted: true, tier: 'PREMIUM' });
+    const daysGranted = Math.round(
+      (trial.expiresAt!.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+    );
+    expect(daysGranted).toBe(TRIAL_DAYS);
+    expect(await getTier(GUILD_ID)).toBe('PREMIUM');
+  });
+
+  // 4 ── premium creates team B ───────────────────────────────────
+
+  it('creates the second team once premium is active', async () => {
+    const interaction = buildTeamInteraction('create', 'Alts');
+
+    await teamCommand.execute(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Alts') })
+    );
+    expect(db.teams).toHaveLength(2);
+    expect(teamByName(GUILD_ID, 'Alts')).toMatchObject({ isDefault: false, createdBy: ADMIN_ID });
+  });
+
+  // 5 ── raids per team ───────────────────────────────────────────
+
+  it('creates raids in both teams, each carrying its own teamId', async () => {
+    await raidCommand.execute(buildRaidInteraction('create', createOptions('Main Night')));
+    await raidCommand.execute(
+      buildRaidInteraction('create', createOptions('Alts Night', 'Alts'))
+    );
+
+    const main = teamByName(GUILD_ID, DEFAULT_TEAM_NAME)!;
+    const alts = teamByName(GUILD_ID, 'Alts')!;
+
+    expect(db.raids).toHaveLength(2);
+    expect(db.raids.find((r) => r.description === 'Main Night')!.teamId).toBe(main.id);
+    expect(db.raids.find((r) => r.description === 'Alts Night')!.teamId).toBe(alts.id);
+    // Attendance rows inherit the raid's team, so per-team stats stay consistent.
+    expect(db.attendance.every((row) => [main.id, alts.id].includes(row.teamId))).toBe(true);
+  });
+
+  // 6 ── team-scoped aggregation ──────────────────────────────────
+
+  it('keeps team B\'s raid out of team A\'s guild stats', async () => {
+    const interaction = buildStatsInteraction('guild', { period: { value: 'month' } });
+
+    await statsCommand.execute(interaction);
+
+    const embed = lastReply(interaction).embeds[0];
+    const totalRaids = embed.data.fields.find((f: any) => /raid/i.test(f.name)).value;
+    expect(totalRaids).toBe('1');
+    expect(JSON.stringify(embed.data)).not.toContain('Alts Night');
+
+    const altsInteraction = buildStatsInteraction('guild', {
+      period: { value: 'month' },
+      team: { value: 'Alts' },
+    });
+    await statsCommand.execute(altsInteraction);
+    const altsEmbed = lastReply(altsInteraction).embeds[0];
+    expect(altsEmbed.data.fields.find((f: any) => /raid/i.test(f.name)).value).toBe('1');
+  });
+
+  // 7 ── downgrade ────────────────────────────────────────────────
+
+  describe('after premium expires', () => {
+    beforeAll(() => {
+      db.guild.premiumExpiresAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      clearTierCache();
+    });
+
+    it('falls back to the free tier', async () => {
+      expect(await getTier(GUILD_ID)).toBe('FREE');
+    });
+
+    it('keeps both teams — nothing is deleted on downgrade', async () => {
+      const interaction = buildTeamInteraction('list');
+
+      await teamCommand.execute(interaction);
+
+      expect(db.teams).toHaveLength(2);
+      expect(prisma.team.delete).not.toHaveBeenCalled();
+
+      const rendered = JSON.stringify(lastReply(interaction).embeds[0].data);
+      expect(rendered).toContain(DEFAULT_TEAM_NAME);
+      expect(rendered).toContain('Alts');
+      // The free-tier nudge rides along, but the listing itself stays complete.
+      expect(lastReply(interaction).content).toContain('Premium');
+    });
+
+    it('still lists the raids of the extra team', async () => {
+      const interaction = buildRaidInteraction('list', { team: { value: 'Alts' } });
+
+      await raidCommand.execute(interaction);
+
+      const rendered = JSON.stringify(lastReply(interaction).embeds[0].data);
+      expect(rendered).toContain('Alts Night');
+      expect(db.raids).toHaveLength(2);
+    });
+
+    it('blocks creating a further team again, without touching existing data', async () => {
+      const interaction = buildTeamInteraction('create', 'Trials');
+
+      await teamCommand.execute(interaction);
+
+      const reply = interaction.reply.mock.calls.at(-1)[0];
+      expect(reply.ephemeral).toBe(true);
+      expect(reply.embeds[0].data.title).toContain('Multiple Teams');
+
+      expect(db.teams).toHaveLength(2);
+      expect(db.raids).toHaveLength(2);
+      expect(teamByName(GUILD_ID, 'Trials')).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/premiumGate.test.ts
+++ b/src/__tests__/premiumGate.test.ts
@@ -14,6 +14,7 @@ function createMockInteraction(guildId: string = 'guild1') {
     deferred: false,
     reply: jest.fn().mockResolvedValue(undefined),
     followUp: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
   } as any;
 }
 
@@ -84,6 +85,23 @@ describe('gateFeature()', () => {
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ ephemeral: true, embeds: expect.any(Array) }),
     );
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('edits the deferred reply instead of following up when a deferral is pending', async () => {
+    mockGetTier.mockResolvedValue('FREE');
+    mockHasFeature.mockReturnValue(false);
+
+    const interaction = createMockInteraction();
+    interaction.deferred = true;
+    const result = await gateFeature(interaction, 'raid.archive', 'en');
+
+    expect(result).toBe(false);
+    // A pending deferral must be resolved, or the "thinking…" placeholder never clears.
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: expect.any(Array) }),
+    );
+    expect(interaction.followUp).not.toHaveBeenCalled();
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/premiumGate.test.ts
+++ b/src/__tests__/premiumGate.test.ts
@@ -59,7 +59,7 @@ describe('gateFeature()', () => {
   });
 
   it('shows the current tier on the upsell embed', async () => {
-    mockGetTier.mockResolvedValue('PREMIUM');
+    mockGetTier.mockResolvedValue('FREE');
     mockHasFeature.mockReturnValue(false);
 
     const interaction = createMockInteraction();
@@ -68,8 +68,8 @@ describe('gateFeature()', () => {
     const embed = embedFrom(interaction.reply);
     const currentPlanField = embed.fields?.find((f: any) => f.name === 'Your Plan');
     const requiredPlanField = embed.fields?.find((f: any) => f.name === 'Required Plan');
-    expect(currentPlanField?.value).toBe('Premium');
-    expect(requiredPlanField?.value).toBe('Pro');
+    expect(currentPlanField?.value).toBe('Free');
+    expect(requiredPlanField?.value).toBe('Premium');
   });
 
   it('uses followUp when interaction already replied', async () => {
@@ -95,15 +95,17 @@ describe('gateFeature()', () => {
     expect(result).toBe(false);
   });
 
-  it('gates PRO features correctly', async () => {
-    mockGetTier.mockResolvedValue('PREMIUM');
+  it('gates the premium-only template feature correctly', async () => {
+    mockGetTier.mockResolvedValue('FREE');
     mockHasFeature.mockReturnValue(false);
 
     const interaction = createMockInteraction();
     const result = await gateFeature(interaction, 'raid.template', 'en');
 
     expect(result).toBe(false);
-    expect(embedFrom(interaction.reply).title).toContain('Pro');
+    const title = embedFrom(interaction.reply).title;
+    expect(title).toContain('Raid Templates');
+    expect(title).toContain('Premium');
   });
 
   it('sends German upsell when language is de', async () => {
@@ -133,8 +135,8 @@ describe('premiumUpsellEmbed()', () => {
   });
 
   it('localizes to German', () => {
-    const embed = premiumUpsellEmbed('raid.template', 'FREE', 'PRO', 'de').toJSON();
-    expect(embed.title).toContain('Pro-Funktion');
+    const embed = premiumUpsellEmbed('raid.template', 'FREE', 'PREMIUM', 'de').toJSON();
+    expect(embed.title).toContain('Premium-Funktion');
     expect(embed.fields?.[0]).toEqual({ name: 'Dein Plan', value: 'Free', inline: true });
   });
 });

--- a/src/__tests__/premiumGate.test.ts
+++ b/src/__tests__/premiumGate.test.ts
@@ -130,8 +130,27 @@ describe('premiumUpsellEmbed()', () => {
     expect(embed.fields).toEqual([
       { name: 'Your Plan', value: 'Free', inline: true },
       { name: 'Required Plan', value: 'Premium', inline: true },
+      { name: '💎 Premium', value: expect.stringContaining('Multiple teams'), inline: false },
     ]);
     expect(embed.footer?.text).toContain('RaidPresence');
+  });
+
+  it('lists the premium perks with multi-team first', () => {
+    const embed = premiumUpsellEmbed('raid.archive', 'FREE', 'PREMIUM', 'en').toJSON();
+    const perks = embed.fields?.find((f: any) => !f.inline)?.value ?? '';
+    const lines = perks.split('\n');
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toContain('Multiple teams');
+    expect(perks).toContain('Unlimited raids');
+    expect(perks).toContain('archives');
+    expect(perks).toContain('analytics');
+  });
+
+  it('localizes the perks field to German', () => {
+    const embed = premiumUpsellEmbed('raid.archive', 'FREE', 'PREMIUM', 'de').toJSON();
+    const perksField = embed.fields?.find((f: any) => !f.inline);
+    expect(perksField?.name).toBe('💎 Premium');
+    expect(perksField?.value).toContain('Mehrere Teams');
   });
 
   it('localizes to German', () => {

--- a/src/__tests__/premiumGate.test.ts
+++ b/src/__tests__/premiumGate.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../database/client');
 jest.mock('../services/entitlementService');
 
-import { gateFeature, premiumUpsellEmbed, premiumFooterHint } from '../middleware/premiumGate';
+import { gateFeature, premiumUpsellEmbed, premiumFooterHint, freeTierHint } from '../middleware/premiumGate';
 import { getTier, hasFeature, FEATURE_TIERS } from '../services/entitlementService';
 
 const mockGetTier = getTier as jest.MockedFunction<typeof getTier>;
@@ -169,5 +169,31 @@ describe('premiumFooterHint()', () => {
   it('localizes to German', () => {
     expect(premiumFooterHint('de')).toMatch(/^-# /);
     expect(premiumFooterHint('de')).toContain('Upgrade auf Premium');
+  });
+});
+
+describe('freeTierHint()', () => {
+  it('returns the hint prefixed with a newline for free guilds', async () => {
+    mockGetTier.mockResolvedValue('FREE');
+
+    expect(await freeTierHint('guild1', 'en')).toBe(`\n${premiumFooterHint('en')}`);
+    expect(mockGetTier).toHaveBeenCalledWith('guild1');
+  });
+
+  it('localizes the hint', async () => {
+    mockGetTier.mockResolvedValue('FREE');
+
+    expect(await freeTierHint('guild1', 'de')).toContain('Upgrade auf Premium');
+  });
+
+  it('returns an empty string for premium guilds', async () => {
+    mockGetTier.mockResolvedValue('PREMIUM');
+
+    expect(await freeTierHint('guild1', 'en')).toBe('');
+  });
+
+  it('returns an empty string outside of a guild without hitting the tier lookup', async () => {
+    expect(await freeTierHint(null, 'en')).toBe('');
+    expect(mockGetTier).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/teamGating.test.ts
+++ b/src/__tests__/teamGating.test.ts
@@ -1,0 +1,100 @@
+jest.mock('../database/client');
+
+import { premiumUpsellEmbed } from '../middleware/premiumGate';
+import {
+  canCreateAdditionalTeam,
+  clearTierCache,
+  FREE_TEAM_LIMIT,
+  hasFeature,
+  PremiumTier,
+} from '../services/entitlementService';
+import prisma from '../database/client';
+
+const mockPrisma = prisma as unknown as {
+  guild: { findUnique: jest.Mock };
+};
+
+/** Makes `getTier(guildId)` resolve to the given tier for the next lookup. */
+function guildOnTier(tier: PremiumTier) {
+  mockPrisma.guild.findUnique.mockResolvedValue({ premiumTier: tier, premiumExpiresAt: null });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // getTier caches per guild for 30s — without this, tier changes between tests leak.
+  clearTierCache();
+});
+
+describe('hasFeature(tier, "team.multi")', () => {
+  it('denies multi-team on FREE', () => {
+    expect(hasFeature('FREE', 'team.multi')).toBe(false);
+  });
+
+  it('allows multi-team on PREMIUM', () => {
+    expect(hasFeature('PREMIUM', 'team.multi')).toBe(true);
+  });
+});
+
+describe('canCreateAdditionalTeam()', () => {
+  it('allows the first team on FREE', async () => {
+    guildOnTier('FREE');
+    expect(await canCreateAdditionalTeam('guild1', 0)).toBe(true);
+  });
+
+  it('blocks a second team on FREE', async () => {
+    guildOnTier('FREE');
+    expect(await canCreateAdditionalTeam('guild1', 1)).toBe(false);
+  });
+
+  it('allows a second team on PREMIUM', async () => {
+    guildOnTier('PREMIUM');
+    expect(await canCreateAdditionalTeam('guild1', 1)).toBe(true);
+  });
+
+  it('allows an eighth team on PREMIUM — the tier is unlimited', async () => {
+    guildOnTier('PREMIUM');
+    expect(await canCreateAdditionalTeam('guild1', 7)).toBe(true);
+  });
+
+  it('caps FREE at exactly FREE_TEAM_LIMIT teams', async () => {
+    guildOnTier('FREE');
+    expect(FREE_TEAM_LIMIT).toBe(1);
+    expect(await canCreateAdditionalTeam('guild1', FREE_TEAM_LIMIT - 1)).toBe(true);
+    clearTierCache();
+    guildOnTier('FREE');
+    expect(await canCreateAdditionalTeam('guild1', FREE_TEAM_LIMIT)).toBe(false);
+  });
+
+  it('treats an expired premium subscription as FREE', async () => {
+    mockPrisma.guild.findUnique.mockResolvedValue({
+      premiumTier: 'PREMIUM',
+      premiumExpiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await canCreateAdditionalTeam('guild1', 1)).toBe(false);
+  });
+});
+
+describe('premiumUpsellEmbed("team.multi")', () => {
+  it('renders the localized feature name and the perks field in German', () => {
+    const embed = premiumUpsellEmbed('team.multi', 'FREE', 'PREMIUM', 'de').toJSON();
+
+    expect(embed.title).toContain('Mehrere Teams');
+    expect(embed.title).toContain('Premium-Funktion');
+    expect(embed.description).toContain('Mehrere Teams');
+
+    const perksField = embed.fields?.find((f: any) => !f.inline);
+    expect(perksField?.name).toBe('💎 Premium');
+    expect(perksField?.value).toContain('Mehrere Teams');
+  });
+
+  it('renders the localized feature name and the perks field in English', () => {
+    const embed = premiumUpsellEmbed('team.multi', 'FREE', 'PREMIUM', 'en').toJSON();
+
+    expect(embed.title).toContain('Multiple Teams');
+    expect(embed.fields?.slice(0, 2)).toEqual([
+      { name: 'Your Plan', value: 'Free', inline: true },
+      { name: 'Required Plan', value: 'Premium', inline: true },
+    ]);
+    expect(embed.fields?.find((f: any) => !f.inline)?.value).toContain('Multiple teams');
+  });
+});

--- a/src/__tests__/teamGating.test.ts
+++ b/src/__tests__/teamGating.test.ts
@@ -7,6 +7,7 @@ import {
   FREE_TEAM_LIMIT,
   hasFeature,
   PremiumTier,
+  teamLimitFor,
 } from '../services/entitlementService';
 import prisma from '../database/client';
 
@@ -71,6 +72,26 @@ describe('canCreateAdditionalTeam()', () => {
       premiumExpiresAt: new Date(Date.now() - 1000),
     });
     expect(await canCreateAdditionalTeam('guild1', 1)).toBe(false);
+  });
+});
+
+describe('teamLimitFor()', () => {
+  it('returns the free cap for FREE guilds so the insert can enforce it', async () => {
+    guildOnTier('FREE');
+    expect(await teamLimitFor('guild1')).toBe(FREE_TEAM_LIMIT);
+  });
+
+  it('returns null (unlimited) for PREMIUM guilds', async () => {
+    guildOnTier('PREMIUM');
+    expect(await teamLimitFor('guild1')).toBeNull();
+  });
+
+  it('falls back to the free cap once premium has expired', async () => {
+    mockPrisma.guild.findUnique.mockResolvedValue({
+      premiumTier: 'PREMIUM',
+      premiumExpiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await teamLimitFor('guild1')).toBe(FREE_TEAM_LIMIT);
   });
 });
 

--- a/src/__tests__/teamService.test.ts
+++ b/src/__tests__/teamService.test.ts
@@ -7,11 +7,13 @@ import {
   listTeams,
   getTeamByName,
   createTeam,
+  createTeamWithinLimit,
   deleteTeam,
   countTeams,
   DEFAULT_TEAM_NAME,
   DuplicateTeamNameError,
   DefaultTeamProtectedError,
+  TeamLimitReachedError,
   TeamNotFoundError,
 } from '../services/teamService';
 
@@ -43,6 +45,9 @@ beforeEach(() => {
   // The shared mock ships a default findFirst result for the raid suites — each test
   // here sets its own expectation explicitly.
   (prisma.team.findFirst as jest.Mock).mockReset();
+  // `clearAllMocks` keeps implementations, so the store/transaction stubs below would leak.
+  (prisma.team.count as jest.Mock).mockReset();
+  (prisma.$transaction as jest.Mock).mockReset();
 });
 
 describe('getDefaultTeam()', () => {
@@ -92,13 +97,33 @@ describe('getDefaultTeam()', () => {
     await expect(getDefaultTeam('guild1')).rejects.toThrow('db down');
   });
 
-  it('rethrows the P2002 error when the re-read still finds nothing', async () => {
+  it('promotes an existing non-default "Main" instead of looping on the name conflict', async () => {
+    const squatter = team({ id: 'team-main', isDefault: false, createdBy: 'user1' });
+    (prisma.team.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null) // no default team
+      .mockResolvedValueOnce(null) // ...still none after the conflict
+      .mockResolvedValueOnce(squatter); // but the name is taken by a non-default team
+    (prisma.team.create as jest.Mock).mockRejectedValue(uniqueConstraintError());
+    (prisma.team.update as jest.Mock).mockResolvedValue({ ...squatter, isDefault: true });
+
+    await expect(getDefaultTeam('guild1')).resolves.toMatchObject({
+      id: 'team-main',
+      isDefault: true,
+    });
+    expect(prisma.team.update as jest.Mock).toHaveBeenCalledWith({
+      where: { id: 'team-main' },
+      data: { isDefault: true },
+    });
+  });
+
+  it('rethrows the P2002 error when neither a default team nor the name holder is found', async () => {
     (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.team.create as jest.Mock).mockRejectedValue(uniqueConstraintError());
 
     await expect(getDefaultTeam('guild1')).rejects.toBeInstanceOf(
       Prisma.PrismaClientKnownRequestError,
     );
+    expect(prisma.team.update as jest.Mock).not.toHaveBeenCalled();
   });
 });
 
@@ -164,6 +189,196 @@ describe('createTeam()', () => {
     (prisma.team.create as jest.Mock).mockRejectedValue(new Error('db down'));
 
     await expect(createTeam('guild1', 'Mythic', 'user1')).rejects.toThrow('db down');
+  });
+});
+
+describe('createTeamWithinLimit()', () => {
+  /** The P2034 error Prisma raises when Postgres refuses to serialize a transaction. */
+  function serializationError() {
+    return new Prisma.PrismaClientKnownRequestError(
+      'Transaction failed due to a write conflict or a deadlock',
+      { code: 'P2034', clientVersion: '5.22.0' },
+    );
+  }
+
+  /**
+   * Installs a `$transaction` mock that emulates Postgres' Serializable isolation over an
+   * in-memory team store: a transaction whose `count()` snapshot is stale by the time it
+   * inserts is rejected with P2034, exactly as SSI would reject it. That is what makes the
+   * FREE=1 invariant testable — without it a mocked transaction can never observe a race.
+   */
+  function installSerializableStore(rows: Array<Record<string, any>> = []) {
+    const store = [...rows];
+    let version = 0;
+    let nextId = 1;
+
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (fn: (tx: any) => Promise<unknown>, options?: { isolationLevel?: string }) => {
+        // The invariant only holds under Serializable — assert the caller asked for it.
+        expect(options?.isolationLevel).toBe('Serializable');
+
+        let snapshot: number | null = null;
+        const tx = {
+          team: {
+            count: async ({ where }: any) => {
+              snapshot = version;
+              return store.filter((row) => row.guildId === where.guildId).length;
+            },
+            create: async ({ data }: any) => {
+              if (snapshot !== null && snapshot !== version) throw serializationError();
+              if (store.some((row) => row.guildId === data.guildId && row.name === data.name)) {
+                throw uniqueConstraintError();
+              }
+              const row = { id: `team-${nextId++}`, ...data };
+              store.push(row);
+              version++;
+              return row;
+            },
+          },
+        };
+
+        return fn(tx);
+      },
+    );
+
+    // The post-retry fallback count reads through the top-level client.
+    (prisma.team.count as jest.Mock).mockImplementation(async ({ where }: any) =>
+      store.filter((row) => row.guildId === where.guildId).length,
+    );
+
+    return store;
+  }
+
+  it('creates the team when the guild is below its limit', async () => {
+    const store = installSerializableStore();
+
+    const created = await createTeamWithinLimit('guild1', 'Mythic', 'user1', 1);
+
+    expect(created).toMatchObject({ guildId: 'guild1', name: 'Mythic', isDefault: false });
+    expect(store).toHaveLength(1);
+  });
+
+  it('refuses the insert when the limit is already reached', async () => {
+    const store = installSerializableStore([team({ id: 'existing' })]);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 1)).rejects.toBeInstanceOf(
+      TeamLimitReachedError,
+    );
+    expect(store).toHaveLength(1);
+  });
+
+  it('lets exactly one of two parallel FREE creates through — the limit is hard', async () => {
+    const store = installSerializableStore();
+
+    const results = await Promise.allSettled([
+      createTeamWithinLimit('guild1', 'Alpha', 'user1', 1),
+      createTeamWithinLimit('guild1', 'Bravo', 'user2', 1),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // The loser must surface as the gateable limit error, never as a raw DB error.
+    expect(rejected[0].reason).toBeInstanceOf(TeamLimitReachedError);
+    // The invariant that matters: a FREE guild ends up with one team, not two.
+    expect(store).toHaveLength(1);
+  });
+
+  it('lets both parallel creates through when the tier allows the second slot', async () => {
+    const store = installSerializableStore();
+
+    const results = await Promise.all([
+      createTeamWithinLimit('guild1', 'Alpha', 'user1', 2),
+      createTeamWithinLimit('guild1', 'Bravo', 'user2', 2),
+    ]);
+
+    expect(results.map((r) => r.name).sort()).toEqual(['Alpha', 'Bravo']);
+    expect(store).toHaveLength(2);
+  });
+
+  it('counts other guilds separately', async () => {
+    const store = installSerializableStore([team({ id: 'other', guildId: 'guild2' })]);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 1)).resolves.toMatchObject({
+      guildId: 'guild1',
+    });
+    expect(store).toHaveLength(2);
+  });
+
+  it('skips the transaction entirely for unlimited (premium) guilds', async () => {
+    const created = team({ id: 't2', name: 'Mythic', isDefault: false });
+    (prisma.team.create as jest.Mock).mockResolvedValue(created);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', null)).resolves.toBe(created);
+    expect(prisma.$transaction as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('maps a duplicate name to DuplicateTeamNameError', async () => {
+    installSerializableStore([team({ id: 'existing', name: 'Mythic', isDefault: false })]);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 5)).rejects.toBeInstanceOf(
+      DuplicateTeamNameError,
+    );
+  });
+
+  it('retries a serialization failure and succeeds when a slot is still free', async () => {
+    let calls = 0;
+    (prisma.$transaction as jest.Mock).mockImplementation(async (fn: any) => {
+      calls++;
+      if (calls === 1) throw serializationError();
+      return { id: 't2', guildId: 'guild1', name: 'Mythic' };
+    });
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 5)).resolves.toMatchObject({
+      id: 't2',
+    });
+    expect(calls).toBe(2);
+  });
+
+  it('reports the limit when the retries are exhausted and the guild is full', async () => {
+    (prisma.$transaction as jest.Mock).mockRejectedValue(serializationError());
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 1)).rejects.toBeInstanceOf(
+      TeamLimitReachedError,
+    );
+  });
+
+  it('rethrows an exhausted serialization failure when the guild is not full', async () => {
+    (prisma.$transaction as jest.Mock).mockRejectedValue(serializationError());
+    (prisma.team.count as jest.Mock).mockResolvedValue(0);
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 5)).rejects.toMatchObject({
+      code: 'P2034',
+    });
+  });
+
+  it('treats a raw 40001 driver error as a serialization failure', async () => {
+    let calls = 0;
+    (prisma.$transaction as jest.Mock).mockImplementation(async () => {
+      calls++;
+      if (calls === 1) {
+        throw new Prisma.PrismaClientUnknownRequestError(
+          'ERROR: could not serialize access due to read/write dependencies (SQLSTATE 40001)',
+          { clientVersion: '5.22.0' },
+        );
+      }
+      return { id: 't2', guildId: 'guild1', name: 'Mythic' };
+    });
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 5)).resolves.toMatchObject({
+      id: 't2',
+    });
+  });
+
+  it('rethrows unrelated transaction errors untouched', async () => {
+    (prisma.$transaction as jest.Mock).mockRejectedValue(new Error('db down'));
+
+    await expect(createTeamWithinLimit('guild1', 'Mythic', 'user1', 1)).rejects.toThrow('db down');
   });
 });
 

--- a/src/__tests__/teamService.test.ts
+++ b/src/__tests__/teamService.test.ts
@@ -1,0 +1,210 @@
+jest.mock('../database/client');
+
+import { Prisma } from '@prisma/client';
+import prisma from '../database/client';
+import {
+  getDefaultTeam,
+  listTeams,
+  getTeamByName,
+  createTeam,
+  deleteTeam,
+  countTeams,
+  DEFAULT_TEAM_NAME,
+  DuplicateTeamNameError,
+  DefaultTeamProtectedError,
+  TeamNotFoundError,
+} from '../services/teamService';
+
+/** Minimal Team row shaped like the Prisma model. */
+function team(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'team-1',
+    guildId: 'guild1',
+    name: DEFAULT_TEAM_NAME,
+    isDefault: true,
+    createdBy: 'system',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  } as any;
+}
+
+/** The P2002 error Prisma raises when `@@unique([guildId, name])` is violated. */
+function uniqueConstraintError() {
+  return new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '5.22.0',
+    meta: { target: ['guildId', 'name'] },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The shared mock ships a default findFirst result for the raid suites — each test
+  // here sets its own expectation explicitly.
+  (prisma.team.findFirst as jest.Mock).mockReset();
+});
+
+describe('getDefaultTeam()', () => {
+  it('returns the existing default team without creating one', async () => {
+    const existing = team({ id: 'team-existing' });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(existing);
+
+    await expect(getDefaultTeam('guild1')).resolves.toBe(existing);
+    expect(prisma.team.findFirst as jest.Mock).toHaveBeenCalledWith({
+      where: { guildId: 'guild1', isDefault: true },
+    });
+    expect(prisma.team.create as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('lazily creates the default team for a guild that has none', async () => {
+    const created = team({ id: 'team-new' });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.team.create as jest.Mock).mockResolvedValue(created);
+
+    await expect(getDefaultTeam('guild1')).resolves.toBe(created);
+    expect(prisma.team.create as jest.Mock).toHaveBeenCalledWith({
+      data: {
+        guildId: 'guild1',
+        name: DEFAULT_TEAM_NAME,
+        isDefault: true,
+        createdBy: 'system',
+      },
+    });
+  });
+
+  it('is idempotent under a P2002 race: re-reads the row the winner wrote', async () => {
+    const winner = team({ id: 'team-winner' });
+    (prisma.team.findFirst as jest.Mock)
+      .mockResolvedValueOnce(null) // initial lookup — nothing there yet
+      .mockResolvedValueOnce(winner); // re-read after losing the race
+    (prisma.team.create as jest.Mock).mockRejectedValue(uniqueConstraintError());
+
+    await expect(getDefaultTeam('guild1')).resolves.toBe(winner);
+    expect(prisma.team.create as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(prisma.team.findFirst as jest.Mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows non-P2002 create errors', async () => {
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.team.create as jest.Mock).mockRejectedValue(new Error('db down'));
+
+    await expect(getDefaultTeam('guild1')).rejects.toThrow('db down');
+  });
+
+  it('rethrows the P2002 error when the re-read still finds nothing', async () => {
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.team.create as jest.Mock).mockRejectedValue(uniqueConstraintError());
+
+    await expect(getDefaultTeam('guild1')).rejects.toBeInstanceOf(
+      Prisma.PrismaClientKnownRequestError,
+    );
+  });
+});
+
+describe('listTeams()', () => {
+  it('orders the default team first, then alphabetically', async () => {
+    const rows = [
+      team({ id: 't1', name: 'Main', isDefault: true }),
+      team({ id: 't2', name: 'Alts', isDefault: false }),
+      team({ id: 't3', name: 'Mythic', isDefault: false }),
+    ];
+    (prisma.team.findMany as jest.Mock).mockResolvedValue(rows);
+
+    await expect(listTeams('guild1')).resolves.toBe(rows);
+    expect(prisma.team.findMany as jest.Mock).toHaveBeenCalledWith({
+      where: { guildId: 'guild1' },
+      orderBy: [{ isDefault: 'desc' }, { name: 'asc' }],
+    });
+  });
+});
+
+describe('getTeamByName()', () => {
+  it('looks up case-insensitively', async () => {
+    const found = team({ id: 't2', name: 'Mythic', isDefault: false });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(found);
+
+    await expect(getTeamByName('guild1', 'mYtHiC')).resolves.toBe(found);
+    expect(prisma.team.findFirst as jest.Mock).toHaveBeenCalledWith({
+      where: {
+        guildId: 'guild1',
+        name: { equals: 'mYtHiC', mode: 'insensitive' },
+      },
+    });
+  });
+
+  it('returns null when no team matches', async () => {
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(getTeamByName('guild1', 'nope')).resolves.toBeNull();
+  });
+});
+
+describe('createTeam()', () => {
+  it('creates a non-default team without premium gating', async () => {
+    const created = team({ id: 't2', name: 'Mythic', isDefault: false, createdBy: 'user1' });
+    (prisma.team.create as jest.Mock).mockResolvedValue(created);
+
+    await expect(createTeam('guild1', 'Mythic', 'user1')).resolves.toBe(created);
+    expect(prisma.team.create as jest.Mock).toHaveBeenCalledWith({
+      data: { guildId: 'guild1', name: 'Mythic', isDefault: false, createdBy: 'user1' },
+    });
+    // Gating belongs to the command layer (Phase 4) — the service must not read tiers.
+    expect(prisma.guild.findUnique as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('throws DuplicateTeamNameError on a duplicate name', async () => {
+    (prisma.team.create as jest.Mock).mockRejectedValue(uniqueConstraintError());
+
+    await expect(createTeam('guild1', 'Mythic', 'user1')).rejects.toBeInstanceOf(
+      DuplicateTeamNameError,
+    );
+  });
+
+  it('rethrows unrelated create errors untouched', async () => {
+    (prisma.team.create as jest.Mock).mockRejectedValue(new Error('db down'));
+
+    await expect(createTeam('guild1', 'Mythic', 'user1')).rejects.toThrow('db down');
+  });
+});
+
+describe('deleteTeam()', () => {
+  it('deletes a non-default team', async () => {
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue(
+      team({ id: 't2', name: 'Mythic', isDefault: false }),
+    );
+    (prisma.team.delete as jest.Mock).mockResolvedValue({} as any);
+
+    await expect(deleteTeam('t2')).resolves.toBeUndefined();
+    expect(prisma.team.delete as jest.Mock).toHaveBeenCalledWith({ where: { id: 't2' } });
+  });
+
+  it('refuses to delete the default team', async () => {
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue(team({ id: 't1', isDefault: true }));
+
+    await expect(deleteTeam('t1')).rejects.toBeInstanceOf(DefaultTeamProtectedError);
+    expect(prisma.team.delete as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('throws TeamNotFoundError for an unknown team', async () => {
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(deleteTeam('ghost')).rejects.toBeInstanceOf(TeamNotFoundError);
+    expect(prisma.team.delete as jest.Mock).not.toHaveBeenCalled();
+  });
+});
+
+describe('countTeams()', () => {
+  it('returns the number of teams in the guild', async () => {
+    (prisma.team.count as jest.Mock).mockResolvedValue(3);
+
+    await expect(countTeams('guild1')).resolves.toBe(3);
+    expect(prisma.team.count as jest.Mock).toHaveBeenCalledWith({
+      where: { guildId: 'guild1' },
+    });
+  });
+
+  it('returns 0 for a guild without teams', async () => {
+    (prisma.team.count as jest.Mock).mockResolvedValue(0);
+    await expect(countTeams('empty')).resolves.toBe(0);
+  });
+});

--- a/src/__tests__/welcomeEmbed.test.ts
+++ b/src/__tests__/welcomeEmbed.test.ts
@@ -36,11 +36,34 @@ describe('buildWelcomeEmbed()', () => {
     const deValue = trialField(de)?.value;
 
     // German locale must render the German trial copy, English the English copy.
-    expect(deValue).toBe(t('de', 'premiumTrialGranted', { tier: t('de', 'premiumTierPremium') }));
-    expect(enValue).toBe(t('en', 'premiumTrialGranted', { tier: t('en', 'premiumTierPremium') }));
+    expect(deValue).toContain(t('de', 'premiumTrialGranted', { tier: t('de', 'premiumTierPremium') }));
+    expect(enValue).toContain(t('en', 'premiumTrialGranted', { tier: t('en', 'premiumTierPremium') }));
 
     // Guard against a regression back to the hardcoded 'en' string.
     expect(deValue).not.toBe(enValue);
     expect(deValue).toContain('Testphase');
+  });
+
+  it('adds the localized multi-team hint to the trial callout', () => {
+    for (const language of ['en', 'de']) {
+      const embed = buildWelcomeEmbed({
+        detectedTimezone: 1,
+        timezoneOffset: 1,
+        trialGranted: true,
+        language,
+      });
+      expect(trialField(embed)?.value).toContain(t(language, 'premiumTrialTeamsHint'));
+    }
+  });
+
+  it('highlights multi-team support in the useful commands field', () => {
+    const embed = buildWelcomeEmbed({
+      detectedTimezone: 1,
+      timezoneOffset: 1,
+      trialGranted: false,
+      language: 'en',
+    });
+    const commands = embed.toJSON().fields?.find((f) => f.name.includes('Useful Commands'));
+    expect(commands?.value).toContain('/team list');
   });
 });

--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -5,9 +5,13 @@
  */
 
 jest.mock('../../database/client');
+jest.mock('../../middleware/premiumGate', () => ({
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 
 import prisma from '../../database/client';
 import command from '../config';
+import { freeTierHint } from '../../middleware/premiumGate';
 
 describe('config command', () => {
   let mockInteraction: any;
@@ -15,8 +19,11 @@ describe('config command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    (freeTierHint as jest.Mock).mockResolvedValue('');
+
     mockInteraction = {
       guild: { id: 'guild-123', name: 'Test Guild' },
+      guildId: 'guild-123',
       isChatInputCommand: jest.fn().mockReturnValue(true),
       deferReply: jest.fn().mockResolvedValue(undefined),
       editReply: jest.fn().mockResolvedValue(undefined),
@@ -84,6 +91,34 @@ describe('config command', () => {
           ]),
         })
       );
+    });
+
+    it('should append the free-tier upsell hint as content', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+        id: 'guild-123',
+        raidLeaderRoles: 'Officer',
+        language: 'de',
+        timezoneOffset: 1,
+      });
+      (freeTierHint as jest.Mock).mockResolvedValue('\n-# upgrade hint');
+
+      await command.execute(mockInteraction);
+
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'de');
+      expect(mockInteraction.editReply.mock.calls[0][0].content).toBe('\n-# upgrade hint');
+    });
+
+    it('should leave content undefined for premium guilds', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+        id: 'guild-123',
+        raidLeaderRoles: 'Officer',
+        language: 'en',
+        timezoneOffset: 1,
+      });
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply.mock.calls[0][0].content).toBeUndefined();
     });
 
     it('should show defaults when roles not configured', async () => {

--- a/src/commands/__tests__/integration/phase1.integration.test.ts
+++ b/src/commands/__tests__/integration/phase1.integration.test.ts
@@ -15,7 +15,11 @@ import { canManageRaids } from '../../../utils/permissions';
 
 jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
-jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 jest.mock('../../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../../database/client';

--- a/src/commands/__tests__/integration/raid-archive.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-archive.integration.test.ts
@@ -11,7 +11,7 @@ import { canManageRaids } from '../../../utils/permissions';
 
 jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
-jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true), freeTierHint: jest.fn().mockResolvedValue('') }));
 jest.mock('../../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 jest.mock('discord.js', () => {
   const actual = jest.requireActual('discord.js');

--- a/src/commands/__tests__/integration/raid-attendance.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-attendance.integration.test.ts
@@ -12,7 +12,7 @@ import { canManageRaids } from '../../../utils/permissions';
 
 jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
-jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true), freeTierHint: jest.fn().mockResolvedValue('') }));
 jest.mock('../../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../../database/client';

--- a/src/commands/__tests__/integration/raid-status.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-status.integration.test.ts
@@ -43,6 +43,8 @@ function buildStatusInteraction(extras: Record<string, any> = {}) {
     reply: jest.fn().mockResolvedValue(undefined),
     options: {
       getSubcommand: jest.fn().mockReturnValue('status'),
+      // No `team` option supplied → default team
+      get: jest.fn().mockReturnValue(undefined),
     },
     ...extras,
   } as any;

--- a/src/commands/__tests__/integration/raid-suggest.integration.test.ts
+++ b/src/commands/__tests__/integration/raid-suggest.integration.test.ts
@@ -11,7 +11,7 @@ import { canManageRaids } from '../../../utils/permissions';
 
 jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
-jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true), freeTierHint: jest.fn().mockResolvedValue('') }));
 jest.mock('../../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../../database/client';

--- a/src/commands/__tests__/performance/phase1.performance.test.ts
+++ b/src/commands/__tests__/performance/phase1.performance.test.ts
@@ -12,7 +12,7 @@ import { canManageRaids } from '../../../utils/permissions';
 
 jest.mock('../../../database/client');
 jest.mock('../../../utils/permissions');
-jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true), freeTierHint: jest.fn().mockResolvedValue('') }));
 jest.mock('../../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../../database/client';

--- a/src/commands/__tests__/raid-attendance.test.ts
+++ b/src/commands/__tests__/raid-attendance.test.ts
@@ -8,7 +8,7 @@ import { canManageRaids } from '../../utils/permissions';
 
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
-jest.mock('../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true), freeTierHint: jest.fn().mockResolvedValue('') }));
 jest.mock('../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 jest.mock('../../utils/attendanceAnalytics', () => {
   const actual = jest.requireActual('../../utils/attendanceAnalytics');

--- a/src/commands/__tests__/raid-attendance.test.ts
+++ b/src/commands/__tests__/raid-attendance.test.ts
@@ -171,9 +171,9 @@ describe('/raid attendance command', () => {
     await command.execute(interaction);
 
     expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
-    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'month');
-    expect(getPlayerRoleDistribution).toHaveBeenCalledWith('user-target', 'guild-123');
-    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'month');
+    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'month', 'team-default');
+    expect(getPlayerRoleDistribution).toHaveBeenCalledWith('user-target', 'guild-123', 'team-default');
+    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'month', 'team-default');
 
     // Should editReply with an embed
     expect(interaction.editReply).toHaveBeenCalledTimes(1);
@@ -218,8 +218,8 @@ describe('/raid attendance command', () => {
 
     await command.execute(interaction);
 
-    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'month');
-    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'month');
+    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'month', 'team-default');
+    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'month', 'team-default');
   });
 
   it('should pass quarter period to analytics', async () => {
@@ -227,8 +227,8 @@ describe('/raid attendance command', () => {
 
     await command.execute(interaction);
 
-    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'quarter');
-    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'quarter');
+    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'quarter', 'team-default');
+    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'quarter', 'team-default');
   });
 
   it('should pass all period to analytics', async () => {
@@ -236,8 +236,8 @@ describe('/raid attendance command', () => {
 
     await command.execute(interaction);
 
-    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'all');
-    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'all');
+    expect(calculatePlayerStats).toHaveBeenCalledWith('user-target', 'guild-123', 'all', 'team-default');
+    expect(getPlayerAttendanceHistory).toHaveBeenCalledWith('user-target', 'guild-123', 'all', 'team-default');
   });
 
   // ── Embed Formatting ───────────────────────────────────────

--- a/src/commands/__tests__/raid-clone.test.ts
+++ b/src/commands/__tests__/raid-clone.test.ts
@@ -53,6 +53,7 @@ function makeSourceRaid(overrides: Record<string, any> = {}) {
   return {
     id: 'source-raid-1',
     guildId: 'guild-123',
+    teamId: 'team-source',
     channelId: 'channel-123',
     raidDate: new Date('2026-03-01T18:00:00Z'),
     description: 'Mythic Raid Night',
@@ -520,6 +521,72 @@ describe('handleCloneRaid()', () => {
       const createCall = (prisma.raid.create as jest.Mock).mock.calls[0][0];
       const storedDate: Date = createCall.data.raidDate;
       expect(storedDate.getTime()).toBe(expected.getTime());
+    });
+  });
+
+  describe('Team context', () => {
+    it('should keep the clone in the source raid team when no team option is given', async () => {
+      setupPrismaMocks(makeSourceRaid({ teamId: 'team-source' }));
+
+      const interaction = buildMockInteraction();
+      await command.execute(interaction);
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: 'team-source' }) })
+      );
+      const attendance = (prisma.raidAttendance.createMany as jest.Mock).mock.calls[0][0].data;
+      expect(attendance.every((record: any) => record.teamId === 'team-source')).toBe(true);
+    });
+
+    it('should fall back to the default team for a pre-migration source raid', async () => {
+      setupPrismaMocks(makeSourceRaid({ teamId: null }));
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        id: 'team-default',
+        guildId: 'guild-123',
+        name: 'Main',
+        isDefault: true,
+        createdBy: 'system',
+      });
+
+      const interaction = buildMockInteraction();
+      await command.execute(interaction);
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: 'team-default' }) })
+      );
+    });
+
+    it('should let an explicit team option win over the source raid team', async () => {
+      setupPrismaMocks(makeSourceRaid({ teamId: 'team-source' }));
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        id: 'team-alts',
+        guildId: 'guild-123',
+        name: 'Alts',
+        isDefault: false,
+        createdBy: 'user-leader',
+      });
+
+      const interaction = buildMockInteraction({ team: { value: 'Alts' } });
+      await command.execute(interaction);
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: 'team-alts' }) })
+      );
+      const attendance = (prisma.raidAttendance.createMany as jest.Mock).mock.calls[0][0].data;
+      expect(attendance.every((record: any) => record.teamId === 'team-alts')).toBe(true);
+    });
+
+    it('should reject an unknown team without creating a raid', async () => {
+      setupPrismaMocks(makeSourceRaid({ teamId: 'team-source' }));
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const interaction = buildMockInteraction({ team: { value: 'Ghosts' } });
+      await command.execute(interaction);
+
+      expect(prisma.raid.create).not.toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Ghosts') })
+      );
     });
   });
 

--- a/src/commands/__tests__/raid-clone.test.ts
+++ b/src/commands/__tests__/raid-clone.test.ts
@@ -9,8 +9,14 @@ import { canManageRaids } from '../../utils/permissions';
 // Mock dependencies before imports that use them
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 
 import prisma from '../../database/client';
+import { freeTierHint } from '../../middleware/premiumGate';
 import command from '../raid';
 
 /**
@@ -116,6 +122,7 @@ function buildMockInteraction(optionOverrides: Record<string, any> = {}, extras:
 
   const mockInteraction: any = {
     isChatInputCommand: jest.fn().mockReturnValue(true),
+    guildId: 'guild-123',
     guild: {
       id: 'guild-123',
       name: 'Test Guild',
@@ -789,6 +796,33 @@ describe('handleCloneRaid()', () => {
           },
         })
       );
+    });
+  });
+
+  describe('success confirmation and free tier hint', () => {
+    const HINT = '\n-# 💎 Upgrade to Premium for multiple teams, archives, analytics & unlimited raids.';
+
+    it('should resolve the deferred reply with a confirmation naming the raid', async () => {
+      const interaction = buildMockInteraction();
+
+      await command.execute(interaction);
+
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '✅ Raid "Mythic Raid Night" cloned successfully with 1 members!',
+        })
+      );
+    });
+
+    it('should append the upsell hint for FREE guilds', async () => {
+      (freeTierHint as jest.Mock).mockResolvedValue(HINT);
+      const interaction = buildMockInteraction();
+
+      await command.execute(interaction);
+
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'en');
+      const content = (interaction.editReply as jest.Mock).mock.calls.at(-1)[0].content;
+      expect(content.endsWith(HINT)).toBe(true);
     });
   });
 });

--- a/src/commands/__tests__/raid-close-cancel.test.ts
+++ b/src/commands/__tests__/raid-close-cancel.test.ts
@@ -19,6 +19,7 @@ function makeRaid(overrides: Record<string, any> = {}) {
     channelId: 'channel-123',
     description: 'Weekly Raid',
     status: 'open',
+    teamId: 'team-default',
     messageId: 'msg-123',
     raidDate: new Date(),
     guild: { language: 'en' },
@@ -136,6 +137,31 @@ describe('handleCloseRaid()', () => {
 
     expect(mockInteraction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('closed') })
+    );
+  });
+
+  it('should name the raid team on multi-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue(makeRaid({ teamId: 'team-alts' }));
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(3);
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '✅ Raid has been closed. (Team: **Alts**)' })
+    );
+  });
+
+  it('should keep the original wording on single-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue(makeRaid());
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '✅ Raid has been closed.' })
     );
   });
 
@@ -259,6 +285,19 @@ describe('handleCancelRaid()', () => {
       expect.objectContaining({
         components: [],
       })
+    );
+  });
+
+  it('should name the raid team on multi-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue(makeRaid({ teamId: 'team-alts' }));
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(2);
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '✅ Raid has been cancelled. (Team: **Alts**)' })
     );
   });
 

--- a/src/commands/__tests__/raid-create.test.ts
+++ b/src/commands/__tests__/raid-create.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockRe
 jest.mock('../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../database/client';
+import { tryConsumeWeeklyRaid } from '../../services/entitlementService';
 import command from '../raid';
 
 /**
@@ -455,5 +456,79 @@ describe('handleCreateRaid()', () => {
     );
     expect(rangedField.value).toContain('MagePlayer');
     expect(rangedField.value).toContain('HunterPlayer');
+  });
+
+  describe('team option', () => {
+    const defaultTeam = {
+      id: 'team-default',
+      guildId: 'guild-123',
+      name: 'Main',
+      isDefault: true,
+      createdBy: 'system',
+    };
+
+    /** Replaces the option getter, keeping the valid base options and adding `team`. */
+    function withTeamOption(team: string | undefined) {
+      const values: Record<string, any> = {
+        date: { value: futureDateStr() },
+        time: { value: '20:00' },
+        title: { value: 'Weekly Raid' },
+        roles: { value: 'role-raider' },
+        ping_roles: { value: false },
+      };
+      if (team !== undefined) values.team = { value: team };
+      mockInteraction.options.get = jest.fn((key: string, required?: boolean) =>
+        values[key] !== undefined ? values[key] : (required ? { value: null } : undefined)
+      );
+    }
+
+    it('should fall back to the default team when no team option is given', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(defaultTeam);
+
+      await command.execute(mockInteraction);
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: 'team-default' }) })
+      );
+      const attendance = (prisma.raidAttendance.createMany as jest.Mock).mock.calls[0][0].data;
+      expect(attendance.every((record: any) => record.teamId === 'team-default')).toBe(true);
+    });
+
+    it('should create the raid for the named team when the team option is given', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        ...defaultTeam,
+        id: 'team-alts',
+        name: 'Alts',
+        isDefault: false,
+      });
+      withTeamOption('Alts');
+
+      await command.execute(mockInteraction);
+
+      expect(prisma.team.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            guildId: 'guild-123',
+            name: { equals: 'Alts', mode: 'insensitive' },
+          }),
+        })
+      );
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: 'team-alts' }) })
+      );
+    });
+
+    it('should reject an unknown team without consuming a weekly raid slot', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+      withTeamOption('Ghosts');
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Ghosts') })
+      );
+      expect(tryConsumeWeeklyRaid).not.toHaveBeenCalled();
+      expect(prisma.raid.create).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/commands/__tests__/raid-create.test.ts
+++ b/src/commands/__tests__/raid-create.test.ts
@@ -9,11 +9,16 @@ import { canManageRaids } from '../../utils/permissions';
 // Mock dependencies before imports that use them
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
-jest.mock('../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 jest.mock('../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../database/client';
 import { tryConsumeWeeklyRaid } from '../../services/entitlementService';
+import { freeTierHint } from '../../middleware/premiumGate';
 import command from '../raid';
 
 /**
@@ -58,6 +63,7 @@ describe('handleCreateRaid()', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (freeTierHint as jest.Mock).mockResolvedValue('');
 
     const rolesCache = new MockCollection<string, any>();
     rolesCache.set('role-raider', { id: 'role-raider', name: 'role-raider' });
@@ -123,6 +129,7 @@ describe('handleCreateRaid()', () => {
 
     mockInteraction = {
       guild: mockGuild,
+      guildId: 'guild-123',
       channel: mockChannel,
       member: mockMember,
       user: { id: 'user-123' },
@@ -528,6 +535,52 @@ describe('handleCreateRaid()', () => {
         expect.objectContaining({ content: expect.stringContaining('Ghosts') })
       );
       expect(tryConsumeWeeklyRaid).not.toHaveBeenCalled();
+      expect(prisma.raid.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('free tier upsell hint', () => {
+    beforeEach(() => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        id: 'team-default',
+        guildId: 'guild-123',
+        name: 'Main',
+        isDefault: true,
+        createdBy: 'system',
+      });
+    });
+
+    const HINT = '\n-# 💎 Upgrade to Premium for multiple teams, archives, analytics & unlimited raids.';
+
+    it('should append the hint to the success confirmation for FREE guilds', async () => {
+      (freeTierHint as jest.Mock).mockResolvedValue(HINT);
+
+      await command.execute(mockInteraction);
+
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'en');
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('created successfully'),
+        })
+      );
+      const content = (mockInteraction.editReply as jest.Mock).mock.calls.at(-1)[0].content;
+      expect(content.endsWith(HINT)).toBe(true);
+    });
+
+    it('should leave the success confirmation untouched for PREMIUM guilds', async () => {
+      await command.execute(mockInteraction);
+
+      const content = (mockInteraction.editReply as jest.Mock).mock.calls.at(-1)[0].content;
+      expect(content).toBe('✅ Raid "Weekly Raid" created successfully with 5 members!');
+    });
+
+    it('should not append the hint to the weekly limit reply (it already carries one)', async () => {
+      (freeTierHint as jest.Mock).mockResolvedValue(HINT);
+      (tryConsumeWeeklyRaid as jest.Mock).mockResolvedValue({ allowed: false, max: 5, resetAt: null });
+
+      await command.execute(mockInteraction);
+
+      expect(freeTierHint).not.toHaveBeenCalled();
       expect(prisma.raid.create).not.toHaveBeenCalled();
     });
   });

--- a/src/commands/__tests__/raid-delete.test.ts
+++ b/src/commands/__tests__/raid-delete.test.ts
@@ -137,6 +137,48 @@ describe('handleDeleteRaid()', () => {
     );
   });
 
+  it('should name the raid team on multi-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue({
+      id: 'raid-123',
+      guildId: 'guild-123',
+      teamId: 'team-alts',
+      description: 'Weekly Raid',
+      messageId: null,
+      channelId: null,
+      guild: { language: 'en' },
+    });
+    (prisma.raid.delete as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(2);
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Team: **Alts**') })
+    );
+  });
+
+  it('should not mention a team on single-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue({
+      id: 'raid-123',
+      guildId: 'guild-123',
+      teamId: 'team-default',
+      description: 'Weekly Raid',
+      messageId: null,
+      channelId: null,
+      guild: { language: 'en' },
+    });
+    (prisma.raid.delete as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+
+    await command.execute(mockInteraction);
+
+    const { content } = (mockInteraction.editReply as jest.Mock).mock.calls[0][0];
+    expect(content).not.toContain('Team:');
+    // Single-team guilds must not even pay for the team lookup.
+    expect(prisma.team.findUnique).not.toHaveBeenCalled();
+  });
+
   it('should handle raid without messageId gracefully', async () => {
     (prisma.raid.findUnique as jest.Mock).mockResolvedValue({
       id: 'raid-123',

--- a/src/commands/__tests__/raid-list.test.ts
+++ b/src/commands/__tests__/raid-list.test.ts
@@ -26,8 +26,20 @@ describe('handleListRaids()', () => {
       reply: jest.fn().mockResolvedValue(undefined),
       options: {
         getSubcommand: jest.fn().mockReturnValue('list'),
+        // No `team` option supplied → default team
+        get: jest.fn().mockReturnValue(undefined),
       },
     };
+
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ language: 'en' });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+      id: 'team-default',
+      guildId: 'guild-123',
+      name: 'Main',
+      isDefault: true,
+      createdBy: 'system',
+    });
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
   });
 
   it('should reject when not in a guild', async () => {
@@ -101,5 +113,83 @@ describe('handleListRaids()', () => {
         orderBy: { raidDate: 'asc' },
       })
     );
+  });
+
+  describe('team option', () => {
+    /** Makes `options.get('team')` return the given value. */
+    function withTeamOption(team: string | undefined) {
+      mockInteraction.options.get = jest.fn((name: string) =>
+        name === 'team' && team !== undefined ? { value: team } : undefined
+      );
+    }
+
+    it('should scope the query to the default team when no team option is given', async () => {
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
+      await command.execute(mockInteraction);
+
+      expect(prisma.raid.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ teamId: 'team-default' }),
+        })
+      );
+    });
+
+    it('should scope the query to the named team when the team option is given', async () => {
+      withTeamOption('Alts');
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        id: 'team-alts',
+        guildId: 'guild-123',
+        name: 'Alts',
+        isDefault: false,
+        createdBy: 'user-123',
+      });
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
+
+      await command.execute(mockInteraction);
+
+      expect(prisma.raid.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ teamId: 'team-alts' }),
+        })
+      );
+    });
+
+    it('should reject an unknown team without querying raids', async () => {
+      withTeamOption('Ghosts');
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await command.execute(mockInteraction);
+
+      expect(prisma.raid.findMany).not.toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Ghosts') })
+      );
+    });
+
+    it('should name the team in the title once the guild has multiple teams', async () => {
+      (prisma.team.count as jest.Mock).mockResolvedValue(2);
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'raid-1',
+          guildId: 'guild-123',
+          teamId: 'team-default',
+          description: 'Heroic Raid',
+          raidDate: new Date(Date.now() + 86400000),
+          attendance: [],
+        },
+      ]);
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: expect.arrayContaining([
+            expect.objectContaining({
+              data: expect.objectContaining({ title: 'Upcoming Raids — Main' }),
+            }),
+          ]),
+        })
+      );
+    });
   });
 });

--- a/src/commands/__tests__/raid-list.test.ts
+++ b/src/commands/__tests__/raid-list.test.ts
@@ -6,8 +6,14 @@
 // Mock dependencies before imports that use them
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 
 import prisma from '../../database/client';
+import { freeTierHint } from '../../middleware/premiumGate';
 import command from '../raid';
 
 describe('handleListRaids()', () => {
@@ -16,8 +22,11 @@ describe('handleListRaids()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    (freeTierHint as jest.Mock).mockResolvedValue('');
+
     mockInteraction = {
       guild: { id: 'guild-123', name: 'Test Guild' },
+      guildId: 'guild-123',
       channel: { id: 'channel-123' },
       member: { user: { id: 'user-123' } },
       isChatInputCommand: jest.fn().mockReturnValue(true),
@@ -189,6 +198,62 @@ describe('handleListRaids()', () => {
             }),
           ]),
         })
+      );
+    });
+  });
+
+  describe('free tier upsell hint', () => {
+    const HINT = '\n-# 💎 Upgrade to Premium for multiple teams, archives, analytics & unlimited raids.';
+
+    it('should append the hint to the empty-list reply for FREE guilds', async () => {
+      (freeTierHint as jest.Mock).mockResolvedValue(HINT);
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
+
+      await command.execute(mockInteraction);
+
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'en');
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Upgrade to Premium') })
+      );
+    });
+
+    it('should send the hint as content alongside the raid list embed for FREE guilds', async () => {
+      (freeTierHint as jest.Mock).mockResolvedValue(HINT);
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'raid-1',
+          guildId: 'guild-123',
+          teamId: 'team-default',
+          description: 'Heroic Raid',
+          raidDate: new Date(Date.now() + 86400000),
+          attendance: [],
+        },
+      ]);
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: HINT, embeds: expect.any(Array) })
+      );
+    });
+
+    it('should leave the raid list reply untouched for PREMIUM guilds', async () => {
+      // freeTierHint resolves to '' for non-FREE guilds — no `content` must be sent.
+      (prisma.raid.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'raid-1',
+          guildId: 'guild-123',
+          teamId: 'team-default',
+          description: 'Heroic Raid',
+          raidDate: new Date(Date.now() + 86400000),
+          attendance: [],
+        },
+      ]);
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: undefined })
       );
     });
   });

--- a/src/commands/__tests__/raid-open.test.ts
+++ b/src/commands/__tests__/raid-open.test.ts
@@ -19,6 +19,7 @@ function makeRaid(overrides: Record<string, any> = {}) {
     channelId: 'channel-123',
     description: 'Weekly Raid',
     status: 'closed',
+    teamId: 'team-default',
     messageId: 'msg-123',
     raidDate: new Date(),
     guild: { language: 'en', raidRoles: ['role-123'] },
@@ -150,6 +151,31 @@ describe('handleOpenRaid()', () => {
 
     expect(mockInteraction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('opened') })
+    );
+  });
+
+  it('should name the raid team on multi-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue(makeRaid({ teamId: 'team-alts' }));
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(2);
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '✅ Raid has been opened. (Team: **Alts**)' })
+    );
+  });
+
+  it('should keep the original wording on single-team guilds', async () => {
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue(makeRaid());
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '✅ Raid has been opened.' })
     );
   });
 

--- a/src/commands/__tests__/raid-refresh.test.ts
+++ b/src/commands/__tests__/raid-refresh.test.ts
@@ -270,4 +270,44 @@ describe('handleRefreshRaid()', () => {
       })
     );
   });
+
+  it('should name the raid team on multi-team guilds', async () => {
+    // Drop any `mockResolvedValueOnce` queue left over from the previous test —
+    // `clearAllMocks()` clears recorded calls but not queued one-shot results.
+    (prisma.raid.findUnique as jest.Mock).mockReset();
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue({
+      id: 'raid-123',
+      guildId: 'guild-123',
+      teamId: 'team-alts',
+      roles: 'Raider',
+      status: 'open',
+      messageId: 'msg-123',
+      channelId: 'channel-123',
+      raidDate: new Date(),
+      description: 'Weekly Raid',
+      guild: { raidRoles: 'Raider', language: 'en' },
+      attendance: [
+        { id: 'att-1', userId: 'user-1', guildId: 'guild-123', status: 'attending' },
+        { id: 'att-2', userId: 'user-2', guildId: 'guild-123', status: 'attending' },
+        { id: 'att-3', userId: 'user-3', guildId: 'guild-123', status: 'attending' },
+      ],
+    });
+
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+      id: 'guild-123',
+      raidRoles: 'Raider',
+      language: 'en',
+    });
+    (prisma.userPreference.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.team.count as jest.Mock).mockResolvedValue(2);
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '✅ No roster changes needed. (Team: **Alts**)',
+      })
+    );
+  });
 });

--- a/src/commands/__tests__/raid-remind.test.ts
+++ b/src/commands/__tests__/raid-remind.test.ts
@@ -203,6 +203,44 @@ describe('handleRemindRaid()', () => {
     });
   });
 
+  describe('Team context', () => {
+    it('should add a team field and suffix on multi-team guilds', async () => {
+      (prisma.raid.findUnique as jest.Mock).mockResolvedValueOnce(makeRaid({ teamId: 'team-alts' }));
+      (prisma.team.count as jest.Mock).mockResolvedValue(2);
+      (prisma.team.findUnique as jest.Mock).mockResolvedValue({ id: 'team-alts', name: 'Alts' });
+
+      const interaction = buildMockInteraction();
+      await command.execute(interaction);
+
+      const channel = await interaction.client.channels.fetch('channel-123');
+      const embed = channel.send.mock.calls[0][0].embeds[0];
+
+      const teamField = embed.data.fields?.find((f: any) => f.name.includes('Team'));
+      expect(teamField).toBeDefined();
+      expect(teamField.value).toBe('Alts');
+
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('(Team: **Alts**)') })
+      );
+    });
+
+    it('should omit the team field on single-team guilds', async () => {
+      (prisma.raid.findUnique as jest.Mock).mockResolvedValueOnce(makeRaid({ teamId: 'team-default' }));
+      (prisma.team.count as jest.Mock).mockResolvedValue(1);
+
+      const interaction = buildMockInteraction();
+      await command.execute(interaction);
+
+      const channel = await interaction.client.channels.fetch('channel-123');
+      const embed = channel.send.mock.calls[0][0].embeds[0];
+
+      expect(embed.data.fields?.find((f: any) => f.name.includes('Team'))).toBeUndefined();
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '✅ Reminder sent for **Sunday Raid Night**.' })
+      );
+    });
+  });
+
   describe('Custom message functionality', () => {
     it('should include custom message in embed when message option is provided', async () => {
       const raid = makeRaid();

--- a/src/commands/__tests__/raid-search.test.ts
+++ b/src/commands/__tests__/raid-search.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
 jest.mock('../../middleware/premiumGate', () => ({
   gateFeature: jest.fn().mockResolvedValue(true),
+  freeTierHint: jest.fn().mockResolvedValue(''),
 }));
 jest.mock('../../utils/archiveManager', () => ({
   archiveRaid: jest.fn().mockResolvedValue('archive-message-1'),

--- a/src/commands/__tests__/raid-search.test.ts
+++ b/src/commands/__tests__/raid-search.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression test suite for the archive-related raid subcommands
+ * (`search`, `archive`, `unarchive`) with multi-team support.
+ *
+ * Focus: the command layer passes the resolved team down to the archive helpers and
+ * names the team in its answers only when the guild actually has more than one.
+ */
+
+jest.mock('../../database/client');
+jest.mock('../../utils/permissions');
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('../../utils/archiveManager', () => ({
+  archiveRaid: jest.fn().mockResolvedValue('archive-message-1'),
+  unarchiveRaid: jest.fn().mockResolvedValue(undefined),
+  searchArchive: jest.fn().mockResolvedValue([]),
+}));
+
+import prisma from '../../database/client';
+import { canManageRaids } from '../../utils/permissions';
+import { archiveRaid, searchArchive, unarchiveRaid } from '../../utils/archiveManager';
+import command from '../raid';
+
+describe('archive subcommands with team context', () => {
+  let mockInteraction: any;
+
+  /** Makes `options.get(name)` answer the given option values. */
+  function withOptions(values: Record<string, string>) {
+    mockInteraction.options.get = jest.fn((name: string) =>
+      name in values ? { value: values[name] } : undefined
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockInteraction = {
+      guild: { id: 'guild-123', name: 'Test Guild' },
+      channel: { id: 'channel-123' },
+      member: { user: { id: 'user-123' } },
+      client: {},
+      isChatInputCommand: jest.fn().mockReturnValue(true),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('search'),
+        get: jest.fn().mockReturnValue(undefined),
+      },
+    };
+
+    (canManageRaids as jest.Mock).mockResolvedValue(true);
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ id: 'guild-123', language: 'en' });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+      id: 'team-default',
+      guildId: 'guild-123',
+      name: 'Main',
+      isDefault: true,
+      createdBy: 'system',
+    });
+    (prisma.team.findUnique as jest.Mock).mockResolvedValue({
+      id: 'team-default',
+      guildId: 'guild-123',
+      name: 'Main',
+      isDefault: true,
+      createdBy: 'system',
+    });
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+    (prisma.raid.findUnique as jest.Mock).mockResolvedValue({
+      id: 'raid-1',
+      guildId: 'guild-123',
+      teamId: 'team-default',
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      withOptions({ query: 'Naxx' });
+    });
+
+    it('should scope the search to the default team when no team option is given', async () => {
+      await command.execute(mockInteraction);
+
+      expect(searchArchive).toHaveBeenCalledWith(
+        expect.objectContaining({ guildId: 'guild-123', query: 'Naxx', teamId: 'team-default' })
+      );
+    });
+
+    it('should scope the search to the named team when the team option is given', async () => {
+      withOptions({ query: 'Naxx', team: 'Alts' });
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue({
+        id: 'team-alts',
+        guildId: 'guild-123',
+        name: 'Alts',
+        isDefault: false,
+        createdBy: 'user-123',
+      });
+
+      await command.execute(mockInteraction);
+
+      expect(searchArchive).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: 'team-alts' })
+      );
+    });
+
+    it('should reject an unknown team without searching', async () => {
+      withOptions({ query: 'Naxx', team: 'Ghosts' });
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await command.execute(mockInteraction);
+
+      expect(searchArchive).not.toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Ghosts') })
+      );
+    });
+
+    it('should name the team in the embed title once the guild has multiple teams', async () => {
+      (prisma.team.count as jest.Mock).mockResolvedValue(2);
+
+      await command.execute(mockInteraction);
+
+      const embed = mockInteraction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).toContain('— Main');
+    });
+
+    it('should keep the original embed title for single-team guilds', async () => {
+      await command.execute(mockInteraction);
+
+      const embed = mockInteraction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).not.toContain('—');
+    });
+  });
+
+  describe('archive', () => {
+    beforeEach(() => {
+      mockInteraction.options.getSubcommand.mockReturnValue('archive');
+      withOptions({ raid_id: 'raid-1' });
+    });
+
+    it('should keep the previous wording for single-team guilds', async () => {
+      await command.execute(mockInteraction);
+
+      expect(archiveRaid).toHaveBeenCalledWith('raid-1', 'guild-123', mockInteraction.client);
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: '✅ Raid archived successfully.',
+      });
+    });
+
+    it('should name the team for multi-team guilds', async () => {
+      (prisma.team.count as jest.Mock).mockResolvedValue(2);
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Team: **Main**') })
+      );
+    });
+  });
+
+  describe('unarchive', () => {
+    beforeEach(() => {
+      mockInteraction.options.getSubcommand.mockReturnValue('unarchive');
+      withOptions({ raid_id: 'raid-1' });
+    });
+
+    it('should keep the previous wording for single-team guilds', async () => {
+      await command.execute(mockInteraction);
+
+      expect(unarchiveRaid).toHaveBeenCalledWith('raid-1', 'guild-123', mockInteraction.client);
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: '✅ Raid restored successfully.',
+      });
+    });
+
+    it('should name the team for multi-team guilds', async () => {
+      (prisma.team.count as jest.Mock).mockResolvedValue(2);
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Team: **Main**') })
+      );
+    });
+  });
+});

--- a/src/commands/__tests__/raid-stats.test.ts
+++ b/src/commands/__tests__/raid-stats.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
 jest.mock('../../middleware/premiumGate', () => ({
   gateFeature: jest.fn().mockResolvedValue(true),
+  freeTierHint: jest.fn().mockResolvedValue(''),
 }));
 jest.mock('../../services/entitlementService', () => ({
   getTier: jest.fn().mockResolvedValue('PREMIUM'),

--- a/src/commands/__tests__/raid-team-scope.test.ts
+++ b/src/commands/__tests__/raid-team-scope.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Cross-command team-scoping suite (RPTIER Phase 6).
+ *
+ * Where `raid-create.test.ts`, `raid-list.test.ts` and `stats-team.test.ts` assert the team
+ * plumbing of one handler each, this suite verifies the scoping end-to-end across handlers:
+ * a raid created for team B must not leak into team A's `raid list` or `stats guild`, a clone
+ * must stay in its source team, and — the important negative — extra teams must not multiply
+ * the FREE weekly raid allowance.
+ *
+ * Deliberately different from the sibling suites: `entitlementService` is NOT mocked, so the
+ * real `tryConsumeWeeklyRaid` runs against the prisma mock's `$transaction` and the guild
+ * fixture's counter. `prisma.raid.findMany` is a real filter over a fixture set rather than a
+ * fixed resolved value, so "does not show up" is actually observed instead of inferred from
+ * the `where` clause alone.
+ */
+
+import { canManageRaids } from '../../utils/permissions';
+
+jest.mock('../../database/client');
+jest.mock('../../utils/permissions');
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
+
+import prisma from '../../database/client';
+import { clearTierCache } from '../../services/entitlementService';
+import raidCommand from '../raid';
+import statsCommand from '../stats';
+
+const GUILD_ID = 'guild-123';
+
+const TEAM_MAIN = {
+  id: 'team-main',
+  guildId: GUILD_ID,
+  name: 'Main',
+  isDefault: true,
+  createdBy: 'system',
+};
+
+const TEAM_ALTS = {
+  id: 'team-alts',
+  guildId: GUILD_ID,
+  name: 'Alts',
+  isDefault: false,
+  createdBy: 'user-leader',
+};
+
+const TEAMS = [TEAM_MAIN, TEAM_ALTS];
+
+/** Minimal Collection-like Map covering the discord.js helpers the handlers use. */
+class MockCollection<K, V> extends Map<K, V> {
+  some(fn: (value: V, key: K, map: this) => boolean): boolean {
+    for (const [key, value] of this) if (fn(value, key, this)) return true;
+    return false;
+  }
+
+  filter(fn: (value: V, key: K, map: this) => boolean): MockCollection<K, V> {
+    const result = new MockCollection<K, V>();
+    for (const [key, value] of this) if (fn(value, key, this)) result.set(key, value);
+    return result;
+  }
+
+  find(fn: (value: V, key: K, map: this) => boolean): V | undefined {
+    for (const [key, value] of this) if (fn(value, key, this)) return value;
+    return undefined;
+  }
+}
+
+function futureDateStr(daysFromNow = 7): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString().split('T')[0];
+}
+
+/** Mutable guild row — the real `tryConsumeWeeklyRaid` reads and writes its counter. */
+let guildRow: Record<string, any>;
+
+/** Raid fixtures the `raid.findMany` mock filters over. */
+let raidFixtures: Array<Record<string, any>>;
+
+let createdRaidCount = 0;
+
+/** Builds a `raid`-command interaction for the given subcommand. */
+function buildRaidInteraction(subcommand: string, options: Record<string, any> = {}) {
+  const rolesCache = new MockCollection<string, any>();
+  rolesCache.set('role-raider', { id: 'role-raider', name: 'role-raider' });
+
+  const memberRolesCache = new MockCollection<string, any>();
+  memberRolesCache.set('role-raider', { id: 'role-raider', name: 'role-raider' });
+
+  const membersCache = new MockCollection<string, any>();
+  membersCache.set('user-200', {
+    user: { bot: false, id: 'user-200' },
+    roles: { cache: memberRolesCache },
+    displayName: 'TankPlayer',
+  });
+  membersCache.set('user-201', {
+    user: { bot: false, id: 'user-201' },
+    roles: { cache: memberRolesCache },
+    displayName: 'HealerPlayer',
+  });
+
+  return {
+    isChatInputCommand: jest.fn().mockReturnValue(true),
+    guildId: GUILD_ID,
+    guild: {
+      id: GUILD_ID,
+      name: 'Test Guild',
+      members: { cache: membersCache, fetch: jest.fn().mockResolvedValue(undefined) },
+      roles: { cache: rolesCache },
+    },
+    channel: {
+      id: 'channel-123',
+      isTextBased: jest.fn().mockReturnValue(true),
+      send: jest.fn().mockResolvedValue({ id: 'message-new' }),
+    },
+    member: {
+      user: { bot: false, id: 'user-leader' },
+      roles: { cache: memberRolesCache },
+      displayName: 'Leader',
+    },
+    user: { id: 'user-leader' },
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+    client: {
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          isTextBased: jest.fn().mockReturnValue(true),
+          messages: { fetch: jest.fn() },
+        }),
+      },
+    },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      get: jest.fn((key: string, required?: boolean) =>
+        options[key] !== undefined ? options[key] : (required ? { value: null } : undefined)),
+    },
+  } as any;
+}
+
+/** Baseline valid options for `raid create`, optionally scoped to a named team. */
+function createOptions(team?: string) {
+  const options: Record<string, any> = {
+    date: { value: futureDateStr() },
+    time: { value: '20:00' },
+    title: { value: 'Weekly Raid' },
+    roles: { value: 'role-raider' },
+    ping_roles: { value: false },
+  };
+  if (team !== undefined) options.team = { value: team };
+  return options;
+}
+
+/** Builds a `stats`-command interaction (no member scanning needed). */
+function buildStatsInteraction(subcommand: string, options: Record<string, any> = {}) {
+  return {
+    isChatInputCommand: jest.fn().mockReturnValue(true),
+    guild: { id: GUILD_ID, name: 'Test Guild' },
+    guildId: GUILD_ID,
+    channel: { id: 'channel-123' },
+    member: { user: { bot: false, id: 'user-leader' }, roles: { cache: new Map() } },
+    user: { id: 'user-leader' },
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      get: jest.fn((key: string, required?: boolean) =>
+        options[key] || (required ? { value: null } : undefined)),
+    },
+  } as any;
+}
+
+/** A raid row as `createRaidEmbed` expects to read it back. */
+function embedRaid(id: string, teamId = TEAM_MAIN.id) {
+  return {
+    id,
+    guildId: GUILD_ID,
+    teamId,
+    channelId: 'channel-123',
+    raidDate: new Date(Date.now() + 86_400_000),
+    description: 'Weekly Raid',
+    roles: 'role-raider',
+    status: 'open',
+    guild: { id: GUILD_ID, language: 'en', timezoneOffset: 0 },
+    attendance: [
+      { userId: 'user-200', username: 'TankPlayer', status: 'attending', wowClass: 'Warrior', wowSpec: 'Protection' },
+      { userId: 'user-201', username: 'HealerPlayer', status: 'attending', wowClass: 'Priest', wowSpec: 'Holy' },
+    ],
+  };
+}
+
+/** Attendance rows for a raid, used as `stats guild` input. */
+function attendanceFor(raidId: string) {
+  return [
+    { raidId, userId: 'user-200', username: 'TankPlayer', status: 'attending' },
+    { raidId, userId: 'user-201', username: 'HealerPlayer', status: 'declined' },
+  ];
+}
+
+describe('team scoping across raid and stats commands', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearTierCache();
+    createdRaidCount = 0;
+    raidFixtures = [];
+
+    guildRow = {
+      id: GUILD_ID,
+      name: 'Test Guild',
+      language: 'en',
+      timezoneOffset: 0,
+      raidRoles: 'role-raider',
+      raidLeaderRoles: 'role-leader',
+      premiumTier: 'PREMIUM',
+      premiumExpiresAt: null,
+      weeklyRaidCount: 0,
+      weeklyRaidCountResetAt: null,
+    };
+
+    (canManageRaids as jest.Mock).mockResolvedValue(true);
+
+    (prisma.guild.findUnique as jest.Mock).mockImplementation(async () => guildRow);
+    (prisma.guild.update as jest.Mock).mockImplementation(async ({ data }: any) => {
+      Object.assign(guildRow, data);
+      return guildRow;
+    });
+
+    // Serves both the default-team lookup (`isDefault: true`) and the case-insensitive
+    // by-name lookup, so a single implementation covers every `resolveTeam` call.
+    (prisma.team.findFirst as jest.Mock).mockImplementation(async ({ where }: any) => {
+      if (where.isDefault) return TEAM_MAIN;
+      const wanted = String(where.name?.equals ?? '').toLowerCase();
+      return TEAMS.find((team) => team.name.toLowerCase() === wanted) ?? null;
+    });
+    (prisma.team.findUnique as jest.Mock).mockImplementation(async ({ where }: any) =>
+      TEAMS.find((team) => team.id === where.id) ?? null);
+    (prisma.team.count as jest.Mock).mockResolvedValue(TEAMS.length);
+
+    // Real filtering rather than a canned result — team leakage becomes observable.
+    (prisma.raid.findMany as jest.Mock).mockImplementation(async ({ where }: any) =>
+      raidFixtures.filter((raid) => {
+        if (where.guildId && raid.guildId !== where.guildId) return false;
+        if (where.teamId && raid.teamId !== where.teamId) return false;
+        if (where.status && raid.status !== where.status) return false;
+        if (where.raidDate?.gte && raid.raidDate < where.raidDate.gte) return false;
+        return true;
+      }));
+
+    (prisma.raid.findUnique as jest.Mock).mockImplementation(async ({ where }: any) =>
+      raidFixtures.find((raid) => raid.id === where.id) ?? embedRaid(where.id));
+
+    (prisma.raid.create as jest.Mock).mockImplementation(async ({ data }: any) => ({
+      id: `raid-created-${++createdRaidCount}`,
+      ...data,
+    }));
+    (prisma.raid.update as jest.Mock).mockResolvedValue({});
+    (prisma.raidAttendance.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+    (prisma.raidAttendance.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.userPreference.upsert as jest.Mock).mockResolvedValue({});
+    (prisma.userPreference.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  // ── raid create ─────────────────────────────────────────────
+
+  describe('raid create', () => {
+    it('writes the default team when no team option is given', async () => {
+      await raidCommand.execute(buildRaidInteraction('create', createOptions()));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: TEAM_MAIN.id }) })
+      );
+      const attendance = (prisma.raidAttendance.createMany as jest.Mock).mock.calls[0][0].data;
+      expect(attendance.every((row: any) => row.teamId === TEAM_MAIN.id)).toBe(true);
+    });
+
+    it('writes the named team when the team option is given', async () => {
+      await raidCommand.execute(buildRaidInteraction('create', createOptions('Alts')));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: TEAM_ALTS.id }) })
+      );
+    });
+
+    it('resolves the team name case-insensitively', async () => {
+      await raidCommand.execute(buildRaidInteraction('create', createOptions('aLtS')));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: TEAM_ALTS.id }) })
+      );
+    });
+
+    it('reports an unknown team and inserts nothing', async () => {
+      const interaction = buildRaidInteraction('create', createOptions('Ghosts'));
+
+      await raidCommand.execute(interaction);
+
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Ghosts') })
+      );
+      expect(prisma.raid.create).not.toHaveBeenCalled();
+      expect(prisma.raidAttendance.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── raid list ───────────────────────────────────────────────
+
+  describe('raid list', () => {
+    beforeEach(() => {
+      raidFixtures = [
+        { ...embedRaid('raid-main-1', TEAM_MAIN.id), description: 'Main Night' },
+        { ...embedRaid('raid-alts-1', TEAM_ALTS.id), description: 'Alts Night' },
+      ];
+    });
+
+    it('hides raids of other teams from the default team listing', async () => {
+      const interaction = buildRaidInteraction('list');
+
+      await raidCommand.execute(interaction);
+
+      const [reply] = interaction.editReply.mock.calls.at(-1);
+      const rendered = JSON.stringify(reply.embeds[0].data);
+      expect(rendered).toContain('Main Night');
+      expect(rendered).not.toContain('Alts Night');
+    });
+
+    it('shows only the named team\'s raids when the team option is given', async () => {
+      const interaction = buildRaidInteraction('list', { team: { value: 'Alts' } });
+
+      await raidCommand.execute(interaction);
+
+      const [reply] = interaction.editReply.mock.calls.at(-1);
+      const rendered = JSON.stringify(reply.embeds[0].data);
+      expect(rendered).toContain('Alts Night');
+      expect(rendered).not.toContain('Main Night');
+    });
+
+    it('reports an empty listing for a team without raids', async () => {
+      raidFixtures = [{ ...embedRaid('raid-alts-1', TEAM_ALTS.id), description: 'Alts Night' }];
+      const interaction = buildRaidInteraction('list');
+
+      await raidCommand.execute(interaction);
+
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('No upcoming raids') })
+      );
+    });
+  });
+
+  // ── raid clone ──────────────────────────────────────────────
+
+  describe('raid clone', () => {
+    /** Source raid living in the non-default team. */
+    function altsSourceRaid() {
+      return {
+        ...embedRaid('source-raid-1', TEAM_ALTS.id),
+        description: 'Alts Night',
+        createdBy: 'user-leader',
+        messageId: 'msg-original',
+        createdFromTemplateId: null,
+        clonedAt: null,
+        isTemplate: false,
+      };
+    }
+
+    it('carries the source raid\'s team over to the clone', async () => {
+      raidFixtures = [altsSourceRaid()];
+
+      await raidCommand.execute(buildRaidInteraction('clone', {
+        raid_id: { value: 'source-raid-1' },
+        date: { value: futureDateStr() },
+      }));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            teamId: TEAM_ALTS.id,
+            createdFromTemplateId: 'source-raid-1',
+          }),
+        })
+      );
+      const attendance = (prisma.raidAttendance.createMany as jest.Mock).mock.calls[0][0].data;
+      expect(attendance.every((row: any) => row.teamId === TEAM_ALTS.id)).toBe(true);
+    });
+
+    it('falls back to the default team for a pre-migration source raid', async () => {
+      raidFixtures = [{ ...altsSourceRaid(), teamId: null }];
+
+      await raidCommand.execute(buildRaidInteraction('clone', {
+        raid_id: { value: 'source-raid-1' },
+        date: { value: futureDateStr() },
+      }));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: TEAM_MAIN.id }) })
+      );
+    });
+
+    it('lets an explicit team option override the source team', async () => {
+      raidFixtures = [{ ...altsSourceRaid(), teamId: TEAM_ALTS.id }];
+
+      await raidCommand.execute(buildRaidInteraction('clone', {
+        raid_id: { value: 'source-raid-1' },
+        date: { value: futureDateStr() },
+        team: { value: 'Main' },
+      }));
+
+      expect(prisma.raid.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ teamId: TEAM_MAIN.id }) })
+      );
+    });
+  });
+
+  // ── stats guild ─────────────────────────────────────────────
+
+  describe('stats guild', () => {
+    beforeEach(() => {
+      const recent = new Date(Date.now() - 2 * 86_400_000);
+      raidFixtures = [
+        {
+          ...embedRaid('raid-main-1', TEAM_MAIN.id),
+          raidDate: recent,
+          attendance: attendanceFor('raid-main-1'),
+        },
+        {
+          ...embedRaid('raid-alts-1', TEAM_ALTS.id),
+          raidDate: recent,
+          attendance: attendanceFor('raid-alts-1'),
+        },
+        {
+          ...embedRaid('raid-alts-2', TEAM_ALTS.id),
+          raidDate: recent,
+          attendance: attendanceFor('raid-alts-2'),
+        },
+      ];
+    });
+
+    /** Reads the "total raids" figure out of the guild-stats embed. */
+    function totalRaidsIn(interaction: any): string {
+      const embed = interaction.editReply.mock.calls.at(-1)[0].embeds[0];
+      const field = embed.data.fields.find((f: any) => /raid/i.test(f.name));
+      return field.value;
+    }
+
+    it('aggregates only the default team\'s raids', async () => {
+      const interaction = buildStatsInteraction('guild');
+
+      await statsCommand.execute(interaction);
+
+      const args = (prisma.raid.findMany as jest.Mock).mock.calls[0][0];
+      expect(args.where.teamId).toBe(TEAM_MAIN.id);
+      expect(totalRaidsIn(interaction)).toBe('1');
+    });
+
+    it('aggregates only the named team\'s raids', async () => {
+      const interaction = buildStatsInteraction('guild', { team: { value: 'Alts' } });
+
+      await statsCommand.execute(interaction);
+
+      const args = (prisma.raid.findMany as jest.Mock).mock.calls[0][0];
+      expect(args.where.teamId).toBe(TEAM_ALTS.id);
+      expect(totalRaidsIn(interaction)).toBe('2');
+    });
+  });
+
+  // ── weekly raid limit is guild-wide ─────────────────────────
+
+  describe('FREE weekly raid limit', () => {
+    beforeEach(() => {
+      guildRow.premiumTier = 'FREE';
+    });
+
+    it('shares the free quota across teams instead of granting one per team', async () => {
+      // Five creates alternating between Main and Alts — the sixth must be blocked no
+      // matter which team it targets, otherwise multi-team would be a limit bypass.
+      const teams = ['Main', 'Alts', 'Main', 'Alts', 'Main'];
+      for (const team of teams) {
+        const interaction = buildRaidInteraction('create', createOptions(team));
+        await raidCommand.execute(interaction);
+        expect(interaction.editReply).toHaveBeenCalledWith(
+          expect.objectContaining({ content: expect.stringContaining('created successfully') })
+        );
+      }
+
+      expect(prisma.raid.create).toHaveBeenCalledTimes(5);
+      expect(guildRow.weeklyRaidCount).toBe(5);
+
+      const blocked = buildRaidInteraction('create', createOptions('Alts'));
+      await raidCommand.execute(blocked);
+
+      expect(blocked.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Weekly raid limit reached') })
+      );
+      expect(prisma.raid.create).toHaveBeenCalledTimes(5);
+    });
+
+    it('keeps the quota unlimited for premium guilds across teams', async () => {
+      guildRow.premiumTier = 'PREMIUM';
+
+      for (let i = 0; i < 6; i++) {
+        await raidCommand.execute(buildRaidInteraction('create', createOptions(i % 2 ? 'Alts' : 'Main')));
+      }
+
+      expect(prisma.raid.create).toHaveBeenCalledTimes(6);
+      expect(guildRow.weeklyRaidCount).toBe(0);
+    });
+  });
+});

--- a/src/commands/__tests__/security.test.ts
+++ b/src/commands/__tests__/security.test.ts
@@ -14,7 +14,11 @@ import * as path from 'path';
 
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
-jest.mock('../../middleware/premiumGate', () => ({ gateFeature: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue('-# hint'),
+  freeTierHint: jest.fn().mockResolvedValue(''),
+}));
 jest.mock('../../services/entitlementService', () => ({ getTier: jest.fn().mockResolvedValue('PREMIUM'), hasFeature: jest.fn().mockReturnValue(true), tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }), skuToTier: jest.fn(), FEATURE_TIERS: {} }));
 
 import prisma from '../../database/client';

--- a/src/commands/__tests__/stats-team.test.ts
+++ b/src/commands/__tests__/stats-team.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
 jest.mock('../../middleware/premiumGate', () => ({
   gateFeature: jest.fn().mockResolvedValue(true),
+  freeTierHint: jest.fn().mockResolvedValue(''),
   premiumFooterHint: jest.fn().mockReturnValue(''),
 }));
 jest.mock('../../services/entitlementService', () => ({
@@ -21,6 +22,7 @@ jest.mock('../../services/entitlementService', () => ({
 
 import prisma from '../../database/client';
 import command from '../stats';
+import { freeTierHint } from '../../middleware/premiumGate';
 
 const DEFAULT_TEAM = {
   id: 'team-default',
@@ -45,6 +47,7 @@ function buildMockInteraction(
   return {
     isChatInputCommand: jest.fn().mockReturnValue(true),
     guild: { id: 'guild-123', name: 'Test Guild' },
+    guildId: 'guild-123',
     channel: { id: 'channel-123' },
     member: { user: { bot: false, id: 'user-leader' }, roles: { cache: new Map() } },
     user: { id: 'user-leader' },
@@ -68,6 +71,7 @@ function withMultipleTeams(team = NAMED_TEAM) {
 describe('/stats team awareness', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (freeTierHint as jest.Mock).mockResolvedValue('');
     (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
       id: 'guild-123',
       language: 'en',
@@ -198,6 +202,35 @@ describe('/stats team awareness', () => {
 
       expect(interaction.editReply.mock.calls[0][0].content).toContain('Ghost');
       expect(prisma.raidAttendance.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── free-tier upsell hint (RPTIER Phase 5) ──────────────────
+
+  describe('free-tier footer hint', () => {
+    const player = { value: 'user-9', user: { id: 'user-9', username: 'Raider', displayName: 'Raider' } };
+
+    const cases: Array<[string, Record<string, any>]> = [
+      ['guild', {}],
+      ['status', {}],
+      ['attendance', { player }],
+    ];
+
+    it.each(cases)('appends the hint as content on %s', async (subcommand, options) => {
+      (freeTierHint as jest.Mock).mockResolvedValue('\n-# upgrade hint');
+
+      const interaction = buildMockInteraction(subcommand, options);
+      await command.execute(interaction);
+
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'en');
+      expect(interaction.editReply.mock.calls[0][0].content).toBe('\n-# upgrade hint');
+    });
+
+    it.each(cases)('leaves content undefined for premium guilds on %s', async (subcommand, options) => {
+      const interaction = buildMockInteraction(subcommand, options);
+      await command.execute(interaction);
+
+      expect(interaction.editReply.mock.calls[0][0].content).toBeUndefined();
     });
   });
 

--- a/src/commands/__tests__/stats-team.test.ts
+++ b/src/commands/__tests__/stats-team.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Test suite for team awareness of the /stats command (RPTIER Phase 4).
+ * Tests: team scoping of `guild`, `status` and `attendance`, the `teamNotFound` path,
+ * and the team name shown in embed titles on multi-team guilds only.
+ */
+
+jest.mock('../../database/client');
+jest.mock('../../utils/permissions');
+jest.mock('../../middleware/premiumGate', () => ({
+  gateFeature: jest.fn().mockResolvedValue(true),
+  premiumFooterHint: jest.fn().mockReturnValue(''),
+}));
+jest.mock('../../services/entitlementService', () => ({
+  getTier: jest.fn().mockResolvedValue('PREMIUM'),
+  hasFeature: jest.fn().mockReturnValue(true),
+  tryConsumeWeeklyRaid: jest.fn().mockResolvedValue({ allowed: true, remaining: 4 }),
+  skuToTier: jest.fn(),
+  FEATURE_TIERS: {},
+  PremiumTier: {},
+}));
+
+import prisma from '../../database/client';
+import command from '../stats';
+
+const DEFAULT_TEAM = {
+  id: 'team-default',
+  guildId: 'guild-123',
+  name: 'Main',
+  isDefault: true,
+  createdBy: 'system',
+};
+
+const NAMED_TEAM = {
+  id: 'team-alpha',
+  guildId: 'guild-123',
+  name: 'Alpha',
+  isDefault: false,
+  createdBy: 'user-leader',
+};
+
+function buildMockInteraction(
+  subcommand: string,
+  options: Record<string, any> = {},
+) {
+  return {
+    isChatInputCommand: jest.fn().mockReturnValue(true),
+    guild: { id: 'guild-123', name: 'Test Guild' },
+    channel: { id: 'channel-123' },
+    member: { user: { bot: false, id: 'user-leader' }, roles: { cache: new Map() } },
+    user: { id: 'user-leader' },
+    deferReply: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(subcommand),
+      get: jest.fn((key: string, required?: boolean) =>
+        options[key] || (required ? { value: null } : undefined)),
+    },
+  } as any;
+}
+
+/** Makes the guild look like it runs several teams, so labels are shown. */
+function withMultipleTeams(team = NAMED_TEAM) {
+  (prisma.team.count as jest.Mock).mockResolvedValue(2);
+  (prisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+}
+
+describe('/stats team awareness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+      id: 'guild-123',
+      language: 'en',
+      timezoneOffset: 0,
+    });
+    (prisma.team.findFirst as jest.Mock).mockResolvedValue(DEFAULT_TEAM);
+    (prisma.team.count as jest.Mock).mockResolvedValue(1);
+    (prisma.raid.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.raidAttendance.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  // ── stats guild ─────────────────────────────────────────────
+
+  describe('guild', () => {
+    it('scopes to the default team when no team option is given', async () => {
+      await command.execute(buildMockInteraction('guild'));
+
+      const args = (prisma.raid.findMany as jest.Mock).mock.calls[0][0];
+      expect(args.where.guildId).toBe('guild-123');
+      expect(args.where.teamId).toBe('team-default');
+    });
+
+    it('scopes to a named team', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(NAMED_TEAM);
+
+      await command.execute(buildMockInteraction('guild', { team: { value: 'Alpha' } }));
+
+      const args = (prisma.raid.findMany as jest.Mock).mock.calls[0][0];
+      expect(args.where.teamId).toBe('team-alpha');
+    });
+
+    it('reports an unknown team and does not query raids', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const interaction = buildMockInteraction('guild', { team: { value: 'Ghost' } });
+      await command.execute(interaction);
+
+      expect(interaction.editReply.mock.calls[0][0].content).toContain('Ghost');
+      expect(prisma.raid.findMany).not.toHaveBeenCalled();
+    });
+
+    it('names the team in the title when the guild has several teams', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(NAMED_TEAM);
+      withMultipleTeams();
+
+      const interaction = buildMockInteraction('guild', { team: { value: 'Alpha' } });
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).toContain('— Alpha');
+    });
+
+    it('leaves the title untouched for single-team guilds', async () => {
+      const interaction = buildMockInteraction('guild');
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).not.toContain('—');
+      expect(prisma.team.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── stats status ────────────────────────────────────────────
+
+  describe('status', () => {
+    it('scopes upcoming raids to the resolved team', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(NAMED_TEAM);
+
+      await command.execute(buildMockInteraction('status', { team: { value: 'Alpha' } }));
+
+      const args = (prisma.raid.findMany as jest.Mock).mock.calls[0][0];
+      expect(args.where.teamId).toBe('team-alpha');
+      expect(args.where.status).toBe('open');
+    });
+
+    it('reports an unknown team and does not query raids', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const interaction = buildMockInteraction('status', { team: { value: 'Ghost' } });
+      await command.execute(interaction);
+
+      expect(interaction.editReply.mock.calls[0][0].content).toContain('Ghost');
+      expect(prisma.raid.findMany).not.toHaveBeenCalled();
+    });
+
+    it('names the team in the title on multi-team guilds', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(NAMED_TEAM);
+      withMultipleTeams();
+
+      const interaction = buildMockInteraction('status', { team: { value: 'Alpha' } });
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).toContain('— Alpha');
+    });
+  });
+
+  // ── stats attendance ────────────────────────────────────────
+
+  describe('attendance', () => {
+    const player = { value: 'user-9', user: { id: 'user-9', username: 'Raider', displayName: 'Raider' } };
+
+    it('passes the team to the analytics queries', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(NAMED_TEAM);
+
+      await command.execute(buildMockInteraction('attendance', { player, team: { value: 'Alpha' } }));
+
+      const calls = (prisma.raidAttendance.findMany as jest.Mock).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [args] of calls) {
+        expect(args.where.teamId).toBe('team-alpha');
+        expect(args.where.userId).toBe('user-9');
+      }
+    });
+
+    it('falls back to the default team', async () => {
+      await command.execute(buildMockInteraction('attendance', { player }));
+
+      const [args] = (prisma.raidAttendance.findMany as jest.Mock).mock.calls[0];
+      expect(args.where.teamId).toBe('team-default');
+    });
+
+    it('reports an unknown team and runs no analytics query', async () => {
+      (prisma.team.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const interaction = buildMockInteraction('attendance', { player, team: { value: 'Ghost' } });
+      await command.execute(interaction);
+
+      expect(interaction.editReply.mock.calls[0][0].content).toContain('Ghost');
+      expect(prisma.raidAttendance.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── raid / suggest: team follows the raid ID ────────────────
+
+  describe('raid-ID based subcommands', () => {
+    const raid = {
+      id: 'raid-1',
+      guildId: 'guild-123',
+      teamId: 'team-alpha',
+      description: 'Mythic Night',
+      raidDate: new Date('2026-03-01T18:00:00Z'),
+      attendance: [],
+      guild: { id: 'guild-123', language: 'en', timezoneOffset: 0 },
+    };
+
+    it('shows the raid\'s team in the stats title on multi-team guilds', async () => {
+      (prisma.raid.findUnique as jest.Mock).mockResolvedValue(raid);
+      withMultipleTeams();
+
+      const interaction = buildMockInteraction('raid', { raid_id: { value: 'raid-1' } });
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).toContain('— Alpha');
+    });
+
+    it('keeps the stats title unchanged on single-team guilds', async () => {
+      (prisma.raid.findUnique as jest.Mock).mockResolvedValue(raid);
+
+      const interaction = buildMockInteraction('raid', { raid_id: { value: 'raid-1' } });
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).not.toContain('— Alpha');
+    });
+
+    it('shows the raid\'s team in the suggest title on multi-team guilds', async () => {
+      (prisma.raid.findUnique as jest.Mock).mockResolvedValue(raid);
+      withMultipleTeams();
+
+      const interaction = buildMockInteraction('suggest', { raid_id: { value: 'raid-1' } });
+      await command.execute(interaction);
+
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+      expect(embed.data.title).toContain('— Alpha');
+    });
+  });
+});

--- a/src/commands/__tests__/team.test.ts
+++ b/src/commands/__tests__/team.test.ts
@@ -20,7 +20,7 @@ import {
   DuplicateTeamNameError,
 } from '../../services/teamService';
 import { canCreateAdditionalTeam, getTier } from '../../services/entitlementService';
-import { gateFeature, premiumFooterHint } from '../../middleware/premiumGate';
+import { gateFeature, freeTierHint } from '../../middleware/premiumGate';
 
 const team = (overrides: Record<string, unknown> = {}) => ({
   id: 'team-1',
@@ -42,7 +42,7 @@ describe('team command', () => {
     (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(true);
     (getTier as jest.Mock).mockResolvedValue('PREMIUM');
     (gateFeature as jest.Mock).mockResolvedValue(false);
-    (premiumFooterHint as jest.Mock).mockReturnValue('-# upgrade hint');
+    (freeTierHint as jest.Mock).mockResolvedValue('');
 
     mockInteraction = {
       guild: { id: 'guild-123', name: 'Test Guild' },
@@ -190,20 +190,21 @@ describe('team command', () => {
       expect(description).toBe('No teams yet.');
     });
 
-    it('should append the premium hint for free guilds with a single team', async () => {
+    it('should append the premium hint for free guilds', async () => {
       (listTeams as jest.Mock).mockResolvedValue([team({ isDefault: true, name: 'Main' })]);
-      (getTier as jest.Mock).mockResolvedValue('FREE');
+      (freeTierHint as jest.Mock).mockResolvedValue('\n-# upgrade hint');
 
       await command.execute(mockInteraction);
 
+      expect(freeTierHint).toHaveBeenCalledWith('guild-123', 'en');
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: '-# upgrade hint' })
+        expect.objectContaining({ content: '\n-# upgrade hint' })
       );
     });
 
     it('should not append the premium hint for premium guilds', async () => {
       (listTeams as jest.Mock).mockResolvedValue([team({ isDefault: true, name: 'Main' })]);
-      (getTier as jest.Mock).mockResolvedValue('PREMIUM');
+      (freeTierHint as jest.Mock).mockResolvedValue('');
 
       await command.execute(mockInteraction);
 

--- a/src/commands/__tests__/team.test.ts
+++ b/src/commands/__tests__/team.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Regression test suite for the /team command.
+ * Tests: create (validation + premium gating + duplicates), list (rendering,
+ * default badge, free-tier hint) and delete (not-found, default-team, cascade).
+ */
+
+jest.mock('../../database/client');
+jest.mock('../../services/teamService');
+jest.mock('../../services/entitlementService');
+jest.mock('../../middleware/premiumGate');
+
+import prisma from '../../database/client';
+import command from '../team';
+import {
+  countTeams,
+  createTeam,
+  deleteTeam,
+  getTeamByName,
+  listTeams,
+  DuplicateTeamNameError,
+} from '../../services/teamService';
+import { canCreateAdditionalTeam, getTier } from '../../services/entitlementService';
+import { gateFeature, premiumFooterHint } from '../../middleware/premiumGate';
+
+const team = (overrides: Record<string, unknown> = {}) => ({
+  id: 'team-1',
+  guildId: 'guild-123',
+  name: 'Alpha',
+  isDefault: false,
+  createdBy: 'user-1',
+  ...overrides,
+});
+
+describe('team command', () => {
+  let mockInteraction: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ language: 'en' });
+    (prisma.raid.count as jest.Mock).mockResolvedValue(0);
+    (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(true);
+    (getTier as jest.Mock).mockResolvedValue('PREMIUM');
+    (gateFeature as jest.Mock).mockResolvedValue(false);
+    (premiumFooterHint as jest.Mock).mockReturnValue('-# upgrade hint');
+
+    mockInteraction = {
+      guild: { id: 'guild-123', name: 'Test Guild' },
+      guildId: 'guild-123',
+      user: { id: 'user-1' },
+      isChatInputCommand: jest.fn().mockReturnValue(true),
+      deferReply: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('list'),
+        getString: jest.fn(() => null),
+      },
+    };
+  });
+
+  describe('command metadata', () => {
+    it('should have name "team"', () => {
+      expect(command.data.name).toBe('team');
+    });
+
+    it('should expose create, list and delete subcommands', () => {
+      const json = command.data.toJSON() as any;
+      expect(json.options.map((o: any) => o.name).sort()).toEqual(['create', 'delete', 'list']);
+    });
+
+    it('should not execute when not a chat input command', async () => {
+      mockInteraction.isChatInputCommand.mockReturnValue(false);
+      await command.execute(mockInteraction);
+      expect(mockInteraction.deferReply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('create subcommand', () => {
+    beforeEach(() => {
+      mockInteraction.options.getSubcommand.mockReturnValue('create');
+      mockInteraction.options.getString.mockReturnValue('Alpha');
+      (countTeams as jest.Mock).mockResolvedValue(1);
+      (createTeam as jest.Mock).mockResolvedValue(team());
+    });
+
+    it('should reject when not in a guild', async () => {
+      mockInteraction.guild = null;
+      await command.execute(mockInteraction);
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('server'), ephemeral: true })
+      );
+      expect(createTeam).not.toHaveBeenCalled();
+    });
+
+    it('should reject whitespace-only names without touching the service', async () => {
+      mockInteraction.options.getString.mockReturnValue('   ');
+      await command.execute(mockInteraction);
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('valid team name'), ephemeral: true })
+      );
+      expect(createTeam).not.toHaveBeenCalled();
+    });
+
+    it('should reject names longer than 50 characters', async () => {
+      mockInteraction.options.getString.mockReturnValue('x'.repeat(51));
+      await command.execute(mockInteraction);
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('valid team name'), ephemeral: true })
+      );
+      expect(createTeam).not.toHaveBeenCalled();
+    });
+
+    it('should gate the second team on the free tier and not create it', async () => {
+      (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(false);
+
+      await command.execute(mockInteraction);
+
+      expect(canCreateAdditionalTeam).toHaveBeenCalledWith('guild-123', 1);
+      expect(gateFeature).toHaveBeenCalledWith(mockInteraction, 'team.multi', 'en');
+      expect(createTeam).not.toHaveBeenCalled();
+      expect(mockInteraction.deferReply).not.toHaveBeenCalled();
+    });
+
+    it('should create the team when allowed and confirm ephemerally', async () => {
+      await command.execute(mockInteraction);
+
+      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+      expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('**Alpha**') })
+      );
+    });
+
+    it('should trim the name before creating', async () => {
+      mockInteraction.options.getString.mockReturnValue('  Alpha  ');
+      await command.execute(mockInteraction);
+      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+    });
+
+    it('should report duplicate names instead of throwing', async () => {
+      (createTeam as jest.Mock).mockRejectedValue(new DuplicateTeamNameError('guild-123', 'Alpha'));
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('already exists') })
+      );
+    });
+
+    it('should use the guild language for responses', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ language: 'de' });
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('erstellt') })
+      );
+    });
+  });
+
+  describe('list subcommand', () => {
+    beforeEach(() => {
+      mockInteraction.options.getSubcommand.mockReturnValue('list');
+    });
+
+    it('should render each team with its raid count and mark the default team', async () => {
+      (listTeams as jest.Mock).mockResolvedValue([
+        team({ id: 'team-default', name: 'Main', isDefault: true }),
+        team({ id: 'team-1', name: 'Alpha' }),
+      ]);
+      (prisma.raid.count as jest.Mock).mockResolvedValue(3);
+
+      await command.execute(mockInteraction);
+
+      const description = mockInteraction.editReply.mock.calls[0][0].embeds[0].data.description;
+      expect(description).toContain('**Main**');
+      expect(description).toContain('3 raids');
+      expect(description).toContain('default');
+      expect(description).toContain('**Alpha**');
+      expect(prisma.raid.count).toHaveBeenCalledWith({ where: { teamId: 'team-default' } });
+    });
+
+    it('should show the empty state when the guild has no teams', async () => {
+      (listTeams as jest.Mock).mockResolvedValue([]);
+
+      await command.execute(mockInteraction);
+
+      const description = mockInteraction.editReply.mock.calls[0][0].embeds[0].data.description;
+      expect(description).toBe('No teams yet.');
+    });
+
+    it('should append the premium hint for free guilds with a single team', async () => {
+      (listTeams as jest.Mock).mockResolvedValue([team({ isDefault: true, name: 'Main' })]);
+      (getTier as jest.Mock).mockResolvedValue('FREE');
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '-# upgrade hint' })
+      );
+    });
+
+    it('should not append the premium hint for premium guilds', async () => {
+      (listTeams as jest.Mock).mockResolvedValue([team({ isDefault: true, name: 'Main' })]);
+      (getTier as jest.Mock).mockResolvedValue('PREMIUM');
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply.mock.calls[0][0].content).toBeUndefined();
+    });
+  });
+
+  describe('delete subcommand', () => {
+    beforeEach(() => {
+      mockInteraction.options.getSubcommand.mockReturnValue('delete');
+      mockInteraction.options.getString.mockReturnValue('Alpha');
+    });
+
+    it('should report unknown teams', async () => {
+      (getTeamByName as jest.Mock).mockResolvedValue(null);
+
+      await command.execute(mockInteraction);
+
+      expect(deleteTeam).not.toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('No team named') })
+      );
+    });
+
+    it('should refuse to delete the default team', async () => {
+      (getTeamByName as jest.Mock).mockResolvedValue(team({ isDefault: true, name: 'Main' }));
+
+      await command.execute(mockInteraction);
+
+      expect(deleteTeam).not.toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('default team cannot be deleted') })
+      );
+    });
+
+    it('should delete the team and warn about cascaded raids', async () => {
+      (getTeamByName as jest.Mock).mockResolvedValue(team());
+      (deleteTeam as jest.Mock).mockResolvedValue(undefined);
+
+      await command.execute(mockInteraction);
+
+      expect(deleteTeam).toHaveBeenCalledWith('team-1');
+      const content = mockInteraction.editReply.mock.calls[0][0].content;
+      expect(content).toContain('**Alpha**');
+      expect(content).toContain('All raids of this team were deleted as well.');
+    });
+
+    it('should use the German cascade note for German guilds', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ language: 'de' });
+      (getTeamByName as jest.Mock).mockResolvedValue(team());
+
+      await command.execute(mockInteraction);
+
+      expect(mockInteraction.editReply.mock.calls[0][0].content).toContain(
+        'Alle Raids dieses Teams wurden ebenfalls gelöscht.'
+      );
+    });
+  });
+});

--- a/src/commands/__tests__/team.test.ts
+++ b/src/commands/__tests__/team.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../services/entitlementService', () => ({
   ...jest.requireActual('../../services/entitlementService'),
   getTier: jest.fn(),
   canCreateAdditionalTeam: jest.fn(),
+  teamLimitFor: jest.fn(),
 }));
 jest.mock('../../middleware/premiumGate');
 
@@ -19,13 +20,18 @@ import prisma from '../../database/client';
 import command from '../team';
 import {
   countTeams,
-  createTeam,
+  createTeamWithinLimit,
   deleteTeam,
   getTeamByName,
   listTeams,
   DuplicateTeamNameError,
+  TeamLimitReachedError,
 } from '../../services/teamService';
-import { canCreateAdditionalTeam, getTier } from '../../services/entitlementService';
+import {
+  canCreateAdditionalTeam,
+  getTier,
+  teamLimitFor,
+} from '../../services/entitlementService';
 import { gateFeature, freeTierHint } from '../../middleware/premiumGate';
 
 const team = (overrides: Record<string, unknown> = {}) => ({
@@ -46,6 +52,7 @@ describe('team command', () => {
     (prisma.guild.findUnique as jest.Mock).mockResolvedValue({ language: 'en' });
     (prisma.raid.count as jest.Mock).mockResolvedValue(0);
     (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(true);
+    (teamLimitFor as jest.Mock).mockResolvedValue(null);
     (getTier as jest.Mock).mockResolvedValue('PREMIUM');
     (gateFeature as jest.Mock).mockResolvedValue(false);
     (freeTierHint as jest.Mock).mockResolvedValue('');
@@ -55,9 +62,12 @@ describe('team command', () => {
       guildId: 'guild-123',
       user: { id: 'user-1' },
       isChatInputCommand: jest.fn().mockReturnValue(true),
+      deferred: false,
+      replied: false,
       deferReply: jest.fn().mockResolvedValue(undefined),
       editReply: jest.fn().mockResolvedValue(undefined),
       reply: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
       options: {
         getSubcommand: jest.fn().mockReturnValue('list'),
         getString: jest.fn(() => null),
@@ -87,7 +97,7 @@ describe('team command', () => {
       mockInteraction.options.getSubcommand.mockReturnValue('create');
       mockInteraction.options.getString.mockReturnValue('Alpha');
       (countTeams as jest.Mock).mockResolvedValue(1);
-      (createTeam as jest.Mock).mockResolvedValue(team());
+      (createTeamWithinLimit as jest.Mock).mockResolvedValue(team());
     });
 
     it('should reject when not in a guild', async () => {
@@ -96,7 +106,7 @@ describe('team command', () => {
       expect(mockInteraction.reply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('server'), ephemeral: true })
       );
-      expect(createTeam).not.toHaveBeenCalled();
+      expect(createTeamWithinLimit).not.toHaveBeenCalled();
     });
 
     it('should reject whitespace-only names without touching the service', async () => {
@@ -105,7 +115,7 @@ describe('team command', () => {
       expect(mockInteraction.reply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('valid team name'), ephemeral: true })
       );
-      expect(createTeam).not.toHaveBeenCalled();
+      expect(createTeamWithinLimit).not.toHaveBeenCalled();
     });
 
     it('should reject names longer than 50 characters', async () => {
@@ -114,7 +124,7 @@ describe('team command', () => {
       expect(mockInteraction.reply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('valid team name'), ephemeral: true })
       );
-      expect(createTeam).not.toHaveBeenCalled();
+      expect(createTeamWithinLimit).not.toHaveBeenCalled();
     });
 
     it('should gate the second team on the free tier and not create it', async () => {
@@ -124,7 +134,7 @@ describe('team command', () => {
 
       expect(canCreateAdditionalTeam).toHaveBeenCalledWith('guild-123', 1);
       expect(gateFeature).toHaveBeenCalledWith(mockInteraction, 'team.multi', 'en');
-      expect(createTeam).not.toHaveBeenCalled();
+      expect(createTeamWithinLimit).not.toHaveBeenCalled();
       expect(mockInteraction.deferReply).not.toHaveBeenCalled();
     });
 
@@ -138,7 +148,7 @@ describe('team command', () => {
 
       await command.execute(mockInteraction);
 
-      expect(createTeam).not.toHaveBeenCalled();
+      expect(createTeamWithinLimit).not.toHaveBeenCalled();
       const reply = mockInteraction.reply.mock.calls[0][0];
       expect(reply.ephemeral).toBe(true);
       expect(reply.embeds[0].data.title).toContain('Multiple Teams');
@@ -153,7 +163,7 @@ describe('team command', () => {
       await command.execute(mockInteraction);
 
       expect(gateFeature).not.toHaveBeenCalled();
-      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+      expect(createTeamWithinLimit).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1', null);
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('**Alpha**') })
       );
@@ -162,7 +172,7 @@ describe('team command', () => {
     it('should create the team when allowed and confirm ephemerally', async () => {
       await command.execute(mockInteraction);
 
-      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+      expect(createTeamWithinLimit).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1', null);
       expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('**Alpha**') })
@@ -172,17 +182,70 @@ describe('team command', () => {
     it('should trim the name before creating', async () => {
       mockInteraction.options.getString.mockReturnValue('  Alpha  ');
       await command.execute(mockInteraction);
-      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+      expect(createTeamWithinLimit).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1', null);
     });
 
     it('should report duplicate names instead of throwing', async () => {
-      (createTeam as jest.Mock).mockRejectedValue(new DuplicateTeamNameError('guild-123', 'Alpha'));
+      (createTeamWithinLimit as jest.Mock).mockRejectedValue(new DuplicateTeamNameError('guild-123', 'Alpha'));
 
       await command.execute(mockInteraction);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('already exists') })
       );
+    });
+
+    it('should hand the free-tier limit to the service so the insert enforces it', async () => {
+      (getTier as jest.Mock).mockResolvedValue('FREE');
+      (countTeams as jest.Mock).mockResolvedValue(0);
+      (teamLimitFor as jest.Mock).mockResolvedValue(1);
+
+      await command.execute(mockInteraction);
+
+      expect(createTeamWithinLimit).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1', 1);
+    });
+
+    it('should answer with the upsell — not an error — when the create loses the limit race', async () => {
+      // Pre-check passed (count was still 0), then a parallel create took the only free slot.
+      (getTier as jest.Mock).mockResolvedValue('FREE');
+      (countTeams as jest.Mock).mockResolvedValue(0);
+      (teamLimitFor as jest.Mock).mockResolvedValue(1);
+      (createTeamWithinLimit as jest.Mock).mockRejectedValue(
+        new TeamLimitReachedError('guild-123', 1),
+      );
+
+      await expect(command.execute(mockInteraction)).resolves.toBeUndefined();
+
+      expect(gateFeature).toHaveBeenCalledWith(mockInteraction, 'team.multi', 'en');
+      expect(mockInteraction.editReply).not.toHaveBeenCalled();
+    });
+
+    it('should edit the deferred reply with the upsell embed when the race is lost', async () => {
+      // Real gate, deferred interaction: the upsell must resolve the pending deferral
+      // instead of leaving a "thinking…" placeholder behind.
+      const { gateFeature: realGateFeature } = jest.requireActual('../../middleware/premiumGate');
+      (gateFeature as jest.Mock).mockImplementation(realGateFeature);
+      (getTier as jest.Mock).mockResolvedValue('FREE');
+      (countTeams as jest.Mock).mockResolvedValue(0);
+      (teamLimitFor as jest.Mock).mockResolvedValue(1);
+      (createTeamWithinLimit as jest.Mock).mockRejectedValue(
+        new TeamLimitReachedError('guild-123', 1),
+      );
+      mockInteraction.deferReply.mockImplementation(async () => {
+        mockInteraction.deferred = true;
+      });
+
+      await command.execute(mockInteraction);
+
+      const edit = mockInteraction.editReply.mock.calls[0][0];
+      expect(edit.embeds[0].data.title).toContain('Multiple Teams');
+      expect(mockInteraction.followUp).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow unrelated service errors', async () => {
+      (createTeamWithinLimit as jest.Mock).mockRejectedValue(new Error('db down'));
+
+      await expect(command.execute(mockInteraction)).rejects.toThrow('db down');
     });
 
     it('should use the guild language for responses', async () => {

--- a/src/commands/__tests__/team.test.ts
+++ b/src/commands/__tests__/team.test.ts
@@ -6,7 +6,13 @@
 
 jest.mock('../../database/client');
 jest.mock('../../services/teamService');
-jest.mock('../../services/entitlementService');
+// Only the tier lookups are mocked; `hasFeature`/`FEATURE_TIERS` stay real so the
+// upsell test below can drive the genuine gateFeature through the FREE code path.
+jest.mock('../../services/entitlementService', () => ({
+  ...jest.requireActual('../../services/entitlementService'),
+  getTier: jest.fn(),
+  canCreateAdditionalTeam: jest.fn(),
+}));
 jest.mock('../../middleware/premiumGate');
 
 import prisma from '../../database/client';
@@ -120,6 +126,37 @@ describe('team command', () => {
       expect(gateFeature).toHaveBeenCalledWith(mockInteraction, 'team.multi', 'en');
       expect(createTeam).not.toHaveBeenCalled();
       expect(mockInteraction.deferReply).not.toHaveBeenCalled();
+    });
+
+    it('should send an ephemeral upsell embed when a free guild hits the team gate', async () => {
+      // Drive the real gate so the FREE path is asserted end-to-end (embed + ephemeral),
+      // not just "gateFeature was called".
+      const { gateFeature: realGateFeature } = jest.requireActual('../../middleware/premiumGate');
+      (gateFeature as jest.Mock).mockImplementation(realGateFeature);
+      (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(false);
+      (getTier as jest.Mock).mockResolvedValue('FREE');
+
+      await command.execute(mockInteraction);
+
+      expect(createTeam).not.toHaveBeenCalled();
+      const reply = mockInteraction.reply.mock.calls[0][0];
+      expect(reply.ephemeral).toBe(true);
+      expect(reply.embeds[0].data.title).toContain('Multiple Teams');
+      expect(reply.embeds[0].data.fields.map((f: any) => f.value)).toContain('Premium');
+    });
+
+    it('should create a second team on the premium tier', async () => {
+      (getTier as jest.Mock).mockResolvedValue('PREMIUM');
+      (canCreateAdditionalTeam as jest.Mock).mockResolvedValue(true);
+      (countTeams as jest.Mock).mockResolvedValue(3);
+
+      await command.execute(mockInteraction);
+
+      expect(gateFeature).not.toHaveBeenCalled();
+      expect(createTeam).toHaveBeenCalledWith('guild-123', 'Alpha', 'user-1');
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('**Alpha**') })
+      );
     });
 
     it('should create the team when allowed and confirm ephemerally', async () => {

--- a/src/commands/__tests__/ux-verification.test.ts
+++ b/src/commands/__tests__/ux-verification.test.ts
@@ -214,8 +214,10 @@ describe('UX: Slash Command Registration', () => {
       (opt: any) => opt.name === 'status'
     );
     expect(statusSub).toBeDefined();
-    // status has no options at all
-    expect(statusSub.options || []).toHaveLength(0);
+    // Only the shared optional `team` option — nothing the user must supply
+    const statusOptions = statusSub.options || [];
+    expect(statusOptions.filter((opt: any) => opt.required)).toHaveLength(0);
+    expect(statusOptions.map((opt: any) => opt.name)).toEqual(['team']);
   });
 
   it('remind subcommand includes message option', () => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -8,6 +8,7 @@ import {
 import prisma from '../database/client';
 import { Command } from '../types';
 import { VERSION } from '../utils/version';
+import { freeTierHint } from '../middleware/premiumGate';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -164,7 +165,8 @@ async function handleViewConfig(interaction: ChatInputCommandInteraction) {
     .setFooter({ text: `Use /config to update any setting | v${VERSION}` })
     .setTimestamp();
 
-  await interaction.editReply({ embeds: [embed] });
+  const hint = await freeTierHint(interaction.guildId, guildData.language || 'en');
+  await interaction.editReply({ embeds: [embed], content: hint || undefined });
 }
 
 async function handleSetLeaderRoles(interaction: ChatInputCommandInteraction) {

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -375,26 +375,28 @@ const command: Command = {
           )
       )
       .addSubcommand((subcommand) =>
-        subcommand
-          .setName('search')
-          .setDescription('Search archived raids')
-          .addStringOption((option) =>
-            option
-              .setName('query')
-              .setDescription('Search query (raid name, player, date)')
-              .setRequired(true)
-          )
-          .addStringOption((option) =>
-            option
-              .setName('period')
-              .setDescription('Time period to search')
-              .addChoices(
-                { name: 'Last 30 days', value: 'month' },
-                { name: 'Last 90 days', value: 'quarter' },
-                { name: 'All time', value: 'all' }
-              )
-              .setRequired(false)
-          )
+        addTeamOption(
+          subcommand
+            .setName('search')
+            .setDescription('Search archived raids')
+            .addStringOption((option) =>
+              option
+                .setName('query')
+                .setDescription('Search query (raid name, player, date)')
+                .setRequired(true)
+            )
+            .addStringOption((option) =>
+              option
+                .setName('period')
+                .setDescription('Time period to search')
+                .addChoices(
+                  { name: 'Last 30 days', value: 'month' },
+                  { name: 'Last 90 days', value: 'quarter' },
+                  { name: 'All time', value: 'all' }
+                )
+                .setRequired(false)
+            )
+        )
       )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents) as SlashCommandBuilder,
 
@@ -1581,8 +1583,13 @@ async function handleArchiveRaid(interaction: ChatInputCommandInteraction) {
 
   try {
     await archiveRaid(raidId, interaction.guild!.id, interaction.client);
+    const archivedRaid = await prisma.raid.findUnique({
+      where: { id: raidId },
+      select: { teamId: true },
+    });
+    const archiveTeamLabel = await getTeamLabel(interaction.guild.id, archivedRaid?.teamId);
     await interaction.editReply({
-      content: '✅ Raid archived successfully.',
+      content: `✅ Raid archived successfully.${teamSuffix(archiveTeamLabel)}`,
     });
   } catch (error) {
     console.error('Error archiving raid:', error);
@@ -1621,8 +1628,13 @@ async function handleUnarchiveRaid(interaction: ChatInputCommandInteraction) {
 
   try {
     await unarchiveRaid(raidId, interaction.guild!.id, interaction.client);
+    const restoredRaid = await prisma.raid.findUnique({
+      where: { id: raidId },
+      select: { teamId: true },
+    });
+    const unarchiveTeamLabel = await getTeamLabel(interaction.guild.id, restoredRaid?.teamId);
     await interaction.editReply({
-      content: '✅ Raid restored successfully.',
+      content: `✅ Raid restored successfully.${teamSuffix(unarchiveTeamLabel)}`,
     });
   } catch (error) {
     console.error('Error restoring raid:', error);
@@ -1664,10 +1676,19 @@ async function handleSearchArchive(interaction: ChatInputCommandInteraction) {
 
   const query = interaction.options.get('query', true).value as string;
   const period = interaction.options.get('period', false)?.value as string || 'month';
+  const teamOption = interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
 
   const guildData = await prisma.guild.findUnique({
     where: { id: interaction.guild.id },
   });
+
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError) {
+    await interaction.editReply({
+      content: t(guildData?.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
 
   const startDate = getStartDate(period);
 
@@ -1675,9 +1696,17 @@ async function handleSearchArchive(interaction: ChatInputCommandInteraction) {
     guildId: interaction.guild.id,
     query,
     startDate,
+    teamId: team.id,
   });
 
   const embed = formatArchiveSearchEmbed(results, query, period, guildData?.language || 'en');
+
+  // Multi-team guilds: make the scope of these results explicit. Single-team guilds keep
+  // the previous title verbatim.
+  const searchTeamLabel = await getTeamLabel(interaction.guild.id, team.id);
+  if (searchTeamLabel) {
+    embed.setTitle(`${embed.data.title} — ${searchTeamLabel}`);
+  }
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -23,6 +23,27 @@ import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
 
 /**
+ * Resolve the guild's default ("Main") team, creating it lazily for guilds that
+ * predate the multi-team migration or were onboarded without one.
+ *
+ * TODO (RPTIER Phase 4): replace call sites with `resolveTeam()` from
+ * `src/utils/teamContext.ts` so raids can target a user-selected team.
+ * @param guildId Discord guild ID
+ * @returns The default team's ID
+ */
+async function resolveDefaultTeamId(guildId: string): Promise<string> {
+  const existing = await prisma.team.findFirst({
+    where: { guildId, isDefault: true },
+  });
+  if (existing) return existing.id;
+
+  const created = await prisma.team.create({
+    data: { guildId, name: 'Main', isDefault: true, createdBy: 'system' },
+  });
+  return created.id;
+}
+
+/**
  * Build role mentions from role IDs or names
  * @param guild Discord guild instance
  * @param roleIds Array of role IDs (snowflake strings) or exact role names (case-sensitive)
@@ -570,9 +591,11 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   }
 
   // Create raid in database
+  const teamId = await resolveDefaultTeamId(interaction.guild.id);
   const raid = await prisma.raid.create({
     data: {
       guildId: interaction.guild.id,
+      teamId,
       channelId: interaction.channel.id,
       raidDate,
       description: title,
@@ -587,6 +610,7 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     const pref = prefsMap.get(userId);
     return {
       raidId: raid.id,
+      teamId: raid.teamId,
       userId,
       guildId: interaction.guild!.id,
       username: member?.displayName || 'Unknown',
@@ -1369,6 +1393,8 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
   const newRaid = await prisma.raid.create({
     data: {
       guildId: interaction.guild!.id,
+      // Clones stay in the source raid's team
+      teamId: sourceRaid.teamId || (await resolveDefaultTeamId(interaction.guild!.id)),
       channelId: interaction.channel.id,
       raidDate,
       description,
@@ -1385,6 +1411,7 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
     const pref = prefsMap.get(userId);
     return {
       raidId: newRaid.id,
+      teamId: newRaid.teamId,
       userId,
       guildId: interaction.guild!.id,
       username: member?.displayName || 'Unknown',
@@ -2108,6 +2135,7 @@ async function handleRefreshRaid(interaction: ChatInputCommandInteraction) {
       const pref = prefsMap.get(userId);
       return {
         raidId: raid.id,
+        teamId: raid.teamId,
         userId,
         username: member?.displayName || 'Unknown',
         status: 'attending' as const,

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -21,13 +21,16 @@ import { isRateLimitError, handleRateLimitError, fetchMembersWithRateLimitHandli
 import { tryConsumeWeeklyRaid } from '../services/entitlementService';
 import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
+import { addTeamOption, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
 
 /**
  * Resolve the guild's default ("Main") team, creating it lazily for guilds that
  * predate the multi-team migration or were onboarded without one.
  *
- * TODO (RPTIER Phase 4): replace call sites with `resolveTeam()` from
- * `src/utils/teamContext.ts` so raids can target a user-selected team.
+ * `raid create` now resolves its team via `resolveTeam()` from
+ * `src/utils/teamContext.ts`; this fallback remains for `clone`, whose source raid may
+ * predate the migration.
+ * TODO (RPTIER Phase 4): replace the remaining clone call site with `resolveTeam()`.
  * @param guildId Discord guild ID
  * @returns The default team's ID
  */
@@ -150,39 +153,41 @@ const command: Command = {
     .setName('raid')
     .setDescription('Manage raid events')
     .addSubcommand((subcommand) =>
-      subcommand
-        .setName('create')
-        .setDescription('Create a new raid event')
-        .addStringOption((option) =>
-          option
-            .setName('date')
-            .setDescription('Raid date (YYYY-MM-DD)')
-            .setRequired(true)
-        )
-        .addStringOption((option) =>
-          option
-            .setName('time')
-            .setDescription('Raid time (HH:MM in 24h format)')
-            .setRequired(true)
-        )
-        .addStringOption((option) =>
-          option
-            .setName('title')
-            .setDescription('Raid title/name')
-            .setRequired(true)
-        )
-        .addStringOption((option) =>
-          option
-            .setName('roles')
-            .setDescription('Discord roles for this raid (@role mentions or comma-separated names/IDs)')
-            .setRequired(true)
-        )
-        .addBooleanOption((option) =>
-          option
-            .setName('ping_roles')
-            .setDescription('Ping the specified roles when creating the raid')
-            .setRequired(false)
-        )
+      addTeamOption(
+        subcommand
+          .setName('create')
+          .setDescription('Create a new raid event')
+          .addStringOption((option) =>
+            option
+              .setName('date')
+              .setDescription('Raid date (YYYY-MM-DD)')
+              .setRequired(true)
+          )
+          .addStringOption((option) =>
+            option
+              .setName('time')
+              .setDescription('Raid time (HH:MM in 24h format)')
+              .setRequired(true)
+          )
+          .addStringOption((option) =>
+            option
+              .setName('title')
+              .setDescription('Raid title/name')
+              .setRequired(true)
+          )
+          .addStringOption((option) =>
+            option
+              .setName('roles')
+              .setDescription('Discord roles for this raid (@role mentions or comma-separated names/IDs)')
+              .setRequired(true)
+          )
+          .addBooleanOption((option) =>
+            option
+              .setName('ping_roles')
+              .setDescription('Ping the specified roles when creating the raid')
+              .setRequired(false)
+          )
+      )
     )
     .addSubcommand((subcommand) =>
       subcommand
@@ -576,7 +581,20 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     memberRolesMap,
   );
 
-  // Check weekly raid limit (free tier: 5/week) — after all validation so we don't waste a slot on invalid input
+  // Resolve the target team before the weekly limit is consumed — an unknown team name is
+  // an input error and must not burn a raid slot.
+  const teamOption = interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError === 'not_found') {
+    await interaction.editReply({
+      content: t(guildData.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
+
+  // Check weekly raid limit (free tier: 5/week) — after all validation so we don't waste a slot on invalid input.
+  // Deliberately guild-wide, not per team: extra teams are a premium convenience and must not
+  // multiply the FREE tier's weekly raid allowance.
   const { allowed, max, resetAt } = await tryConsumeWeeklyRaid(interaction.guild.id);
   if (!allowed) {
     const lang = guildData.language || 'en';
@@ -591,11 +609,10 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   }
 
   // Create raid in database
-  const teamId = await resolveDefaultTeamId(interaction.guild.id);
   const raid = await prisma.raid.create({
     data: {
       guildId: interaction.guild.id,
-      teamId,
+      teamId: team.id,
       channelId: interaction.channel.id,
       raidDate,
       description: title,
@@ -610,7 +627,9 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     const pref = prefsMap.get(userId);
     return {
       raidId: raid.id,
-      teamId: raid.teamId,
+      // Denormalised from the raid we just created — read from the resolved team rather
+      // than the create result so it is never undefined.
+      teamId: team.id,
       userId,
       guildId: interaction.guild!.id,
       username: member?.displayName || 'Unknown',

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -21,8 +21,21 @@ import { isRateLimitError, handleRateLimitError, fetchMembersWithRateLimitHandli
 import { tryConsumeWeeklyRaid } from '../services/entitlementService';
 import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
-import { addTeamOption, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
+import { addTeamOption, getTeamLabel, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
 import { countTeams } from '../services/teamService';
+
+/**
+ * Suffix that names the raid's team in a confirmation message.
+ *
+ * The raid-ID based subcommands (`delete`, `close`, `open`, `cancel`, `remind`, `refresh`)
+ * take no `team` option — the ID already pins the team — but on multi-team guilds the
+ * leader needs to see which team they just touched. `getTeamLabel()` returns `null` for
+ * single-team guilds, so their wording is unchanged.
+ * @param label Team name from {@link getTeamLabel}, or `null`
+ */
+function teamSuffix(label: string | null): string {
+  return label ? ` (Team: **${label}**)` : '';
+}
 
 /**
  * Resolve the guild's default ("Main") team, creating it lazily for guilds that
@@ -1045,8 +1058,12 @@ async function handleDeleteRaid(interaction: ChatInputCommandInteraction) {
     where: { id: raidId },
   });
 
+  const deleteTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   await interaction.editReply({
-    content: t(raid.guild.language || 'en', 'raidDeletedSuccess', { title: raid.description || 'Raid' }),
+    content:
+      t(raid.guild.language || 'en', 'raidDeletedSuccess', { title: raid.description || 'Raid' }) +
+      teamSuffix(deleteTeamLabel),
   });
 }
 
@@ -1737,8 +1754,10 @@ async function handleCloseRaid(interaction: ChatInputCommandInteraction) {
     }
   }
 
+  const closeTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   await interaction.editReply({
-    content: '✅ Raid has been closed.',
+    content: `✅ Raid has been closed.${teamSuffix(closeTeamLabel)}`,
   });
 }
 
@@ -1842,8 +1861,10 @@ async function handleOpenRaid(interaction: ChatInputCommandInteraction) {
     }
   }
 
+  const openTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   await interaction.editReply({
-    content: '✅ Raid has been opened.',
+    content: `✅ Raid has been opened.${teamSuffix(openTeamLabel)}`,
   });
 }
 
@@ -1919,8 +1940,10 @@ async function handleCancelRaid(interaction: ChatInputCommandInteraction) {
     }
   }
 
+  const cancelTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   await interaction.editReply({
-    content: '✅ Raid has been cancelled.',
+    content: `✅ Raid has been cancelled.${teamSuffix(cancelTeamLabel)}`,
   });
 }
 
@@ -2001,11 +2024,18 @@ async function handleRemindRaid(interaction: ChatInputCommandInteraction) {
   const timestamp = Math.floor(raid.raidDate.getTime() / 1000);
   const trans = getTranslations(raid.guild.language || 'en');
 
+  const remindTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   // Build fields array
   const fields: { name: string; value: string; inline: boolean }[] = [
     { name: '📅 Date & Time', value: `<t:${timestamp}:F> (<t:${timestamp}:R>)`, inline: false },
     { name: '👥 Current Attendance', value: `${attendingCount} confirmed`, inline: false },
   ];
+
+  // Public reminder: on multi-team guilds spell out which team is being pinged.
+  if (remindTeamLabel) {
+    fields.push({ name: '🛡️ Team', value: remindTeamLabel, inline: false });
+  }
 
   if (customMessage) {
     // Truncate message to 1024 chars if needed (Discord embed field limit)
@@ -2047,7 +2077,7 @@ async function handleRemindRaid(interaction: ChatInputCommandInteraction) {
   });
 
   await interaction.editReply({
-    content: `✅ Reminder sent for **${raid.description}**.`,
+    content: `✅ Reminder sent for **${raid.description}**.${teamSuffix(remindTeamLabel)}`,
   });
 }
 
@@ -2245,13 +2275,15 @@ async function handleRefreshRaid(interaction: ChatInputCommandInteraction) {
   }
 
   // Report changes
+  const refreshTeamLabel = await getTeamLabel(interaction.guild.id, raid.teamId);
+
   if (newMembers.length > 0 || membersToRemove.length > 0) {
     await interaction.editReply({
-      content: `✅ Raid refreshed. Added ${newMembers.length} new member(s), removed ${membersToRemove.length} member(s).`,
+      content: `✅ Raid refreshed. Added ${newMembers.length} new member(s), removed ${membersToRemove.length} member(s).${teamSuffix(refreshTeamLabel)}`,
     });
   } else {
     await interaction.editReply({
-      content: '✅ No roster changes needed.',
+      content: `✅ No roster changes needed.${teamSuffix(refreshTeamLabel)}`,
     });
   }
 }

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -19,7 +19,7 @@ import { archiveRaid, unarchiveRaid, searchArchive } from '../utils/archiveManag
 import { formatArchiveSearchEmbed } from '../utils/archiveFormatter';
 import { isRateLimitError, handleRateLimitError, fetchMembersWithRateLimitHandling } from '../utils/rateLimitHandler';
 import { tryConsumeWeeklyRaid } from '../services/entitlementService';
-import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
+import { gateFeature, premiumFooterHint, freeTierHint } from '../middleware/premiumGate';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
 import { addTeamOption, getTeamLabel, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
 import { countTeams } from '../services/teamService';
@@ -721,9 +721,10 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     data: { messageId: message.id },
   });
 
-  // Send ephemeral confirmation to command user
+  // Send ephemeral confirmation to command user — FREE guilds get the premium nudge appended.
   await interaction.editReply({
-    content: `✅ Raid "${title}" created successfully with ${eligibleMembers.size} members!`,
+    content: `✅ Raid "${title}" created successfully with ${eligibleMembers.size} members!`
+      + (await freeTierHint(interaction.guildId, guildData.language || 'en')),
   });
 }
 
@@ -971,11 +972,14 @@ async function handleListRaids(interaction: ChatInputCommandInteraction) {
   // guilds keep the exact wording they had before multi-team support.
   const isMultiTeam = (await countTeams(interaction.guild.id)) > 1;
 
+  // FREE guilds get the premium nudge on both successful list outcomes (empty and populated).
+  const listHint = await freeTierHint(interaction.guildId, listGuildData?.language || 'en');
+
   if (raids.length === 0) {
     await interaction.editReply({
-      content: isMultiTeam
+      content: (isMultiTeam
         ? `📅 No upcoming raids found for **${team.name}**.`
-        : '📅 No upcoming raids found.',
+        : '📅 No upcoming raids found.') + listHint,
     });
     return;
   }
@@ -996,7 +1000,7 @@ async function handleListRaids(interaction: ChatInputCommandInteraction) {
     .setFooter({ text: `v${VERSION}` })
     .setTimestamp();
 
-  await interaction.editReply({ embeds: [embed] });
+  await interaction.editReply({ embeds: [embed], content: listHint || undefined });
 }
 
 async function handleDeleteRaid(interaction: ChatInputCommandInteraction) {
@@ -1548,6 +1552,12 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
   await prisma.raid.update({
     where: { id: newRaid.id },
     data: { messageId: message.id },
+  });
+
+  // Resolve the deferred ephemeral reply with a confirmation — FREE guilds get the premium nudge appended.
+  await interaction.editReply({
+    content: `✅ Raid "${description}" cloned successfully with ${eligibleMembers.size} members!`
+      + (await freeTierHint(interaction.guildId, guildData.language || 'en')),
   });
   return;
 }

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -22,15 +22,15 @@ import { tryConsumeWeeklyRaid } from '../services/entitlementService';
 import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
 import { getEffectivePrefsMap, normalizeRoleIds } from '../utils/rolePreference';
 import { addTeamOption, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
+import { countTeams } from '../services/teamService';
 
 /**
  * Resolve the guild's default ("Main") team, creating it lazily for guilds that
  * predate the multi-team migration or were onboarded without one.
  *
- * `raid create` now resolves its team via `resolveTeam()` from
- * `src/utils/teamContext.ts`; this fallback remains for `clone`, whose source raid may
- * predate the migration.
- * TODO (RPTIER Phase 4): replace the remaining clone call site with `resolveTeam()`.
+ * `raid create`, `raid list` and `raid clone` resolve their team via `resolveTeam()` from
+ * `src/utils/teamContext.ts`. This fallback remains only for `clone` without an explicit
+ * `team` option, where the source raid may predate the migration and carry no `teamId`.
  * @param guildId Discord guild ID
  * @returns The default team's ID
  */
@@ -190,9 +190,11 @@ const command: Command = {
       )
     )
     .addSubcommand((subcommand) =>
-      subcommand
-        .setName('list')
-        .setDescription('List all upcoming raids')
+      addTeamOption(
+        subcommand
+          .setName('list')
+          .setDescription('List all upcoming raids')
+      )
     )
     .addSubcommand((subcommand) =>
       subcommand
@@ -307,34 +309,36 @@ const command: Command = {
       )
      )
      .addSubcommand((subcommand) =>
-       subcommand
-         .setName('clone')
-         .setDescription('Clone an existing raid to create a new one')
-         .addStringOption((option) =>
-           option
-             .setName('raid_id')
-             .setDescription('The ID of the raid to clone')
-             .setRequired(true)
-         )
-         .addStringOption((option) =>
-           option
-             .setName('date')
-             .setDescription('New raid date (YYYY-MM-DD)')
-             .setRequired(true)
-         )
-         .addStringOption((option) =>
-           option
-             .setName('time')
-             .setDescription('New raid time (HH:MM in 24h format)')
-             .setRequired(false)
-         )
-         .addStringOption((option) =>
-           option
-             .setName('title')
-             .setDescription('New raid title (optional, defaults to original)')
-             .setRequired(false)
-         )
+       addTeamOption(
+         subcommand
+           .setName('clone')
+           .setDescription('Clone an existing raid to create a new one')
+           .addStringOption((option) =>
+             option
+               .setName('raid_id')
+               .setDescription('The ID of the raid to clone')
+               .setRequired(true)
+           )
+           .addStringOption((option) =>
+             option
+               .setName('date')
+               .setDescription('New raid date (YYYY-MM-DD)')
+               .setRequired(true)
+           )
+           .addStringOption((option) =>
+             option
+               .setName('time')
+               .setDescription('New raid time (HH:MM in 24h format)')
+               .setRequired(false)
+           )
+           .addStringOption((option) =>
+             option
+               .setName('title')
+               .setDescription('New raid title (optional, defaults to original)')
+               .setRequired(false)
+           )
        )
+      )
       .addSubcommand((subcommand) =>
         subcommand
           .setName('archive')
@@ -917,10 +921,25 @@ async function handleListRaids(interaction: ChatInputCommandInteraction) {
 
   await interaction.deferReply({ ephemeral: true });
 
+  const listGuildData = await prisma.guild.findUnique({
+    where: { id: interaction.guild.id },
+    select: { language: true },
+  });
+
+  const teamOption = interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError === 'not_found') {
+    await interaction.editReply({
+      content: t(listGuildData?.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
+
   const now = new Date();
   const raids = await prisma.raid.findMany({
     where: {
       guildId: interaction.guild.id,
+      teamId: team.id,
       raidDate: {
         gte: now,
       },
@@ -933,15 +952,21 @@ async function handleListRaids(interaction: ChatInputCommandInteraction) {
     },
   });
 
+  // Only disambiguate by team once the guild actually has more than one — single-team
+  // guilds keep the exact wording they had before multi-team support.
+  const isMultiTeam = (await countTeams(interaction.guild.id)) > 1;
+
   if (raids.length === 0) {
     await interaction.editReply({
-      content: '📅 No upcoming raids found.',
+      content: isMultiTeam
+        ? `📅 No upcoming raids found for **${team.name}**.`
+        : '📅 No upcoming raids found.',
     });
     return;
   }
 
   const embed = new EmbedBuilder()
-    .setTitle('Upcoming Raids')
+    .setTitle(isMultiTeam ? `Upcoming Raids — ${team.name}` : 'Upcoming Raids')
     .setColor(0x00ae86)
     .setDescription(
       raids
@@ -1280,6 +1305,22 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
   // Get guild settings for timezone
   const guildData = sourceRaid.guild;
 
+  // An explicitly named team wins over the source raid's team. Resolved up front so an
+  // unknown name fails before the expensive member scanning, while the source-team
+  // fallback stays lazy further down (it may have to create the default team).
+  const teamOption = interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
+  let explicitTeamId: string | undefined;
+  if (teamOption?.trim()) {
+    const { team, error: teamError } = await resolveTeam(interaction.guild!.id, teamOption);
+    if (teamError === 'not_found') {
+      await interaction.editReply({
+        content: t(guildData.language || 'en', 'teamNotFound', { name: teamOption }),
+      });
+      return;
+    }
+    explicitTeamId = team.id;
+  }
+
   // Parse and validate date
   const dateParts = dateStr.split('-');
   const year = parseInt(dateParts[0], 10);
@@ -1408,12 +1449,16 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
   // Determine description
   const description = customTitle || sourceRaid.description || 'Cloned Raid';
 
+  // Without an explicit option the clone stays in the source raid's team; the default-team
+  // fallback covers source raids that predate the multi-team migration.
+  const targetTeamId =
+    explicitTeamId || sourceRaid.teamId || (await resolveDefaultTeamId(interaction.guild!.id));
+
   // Create cloned raid
   const newRaid = await prisma.raid.create({
     data: {
       guildId: interaction.guild!.id,
-      // Clones stay in the source raid's team
-      teamId: sourceRaid.teamId || (await resolveDefaultTeamId(interaction.guild!.id)),
+      teamId: targetTeamId,
       channelId: interaction.channel.id,
       raidDate,
       description,
@@ -1430,7 +1475,8 @@ async function handleCloneRaid(interaction: ChatInputCommandInteraction) {
     const pref = prefsMap.get(userId);
     return {
       raidId: newRaid.id,
-      teamId: newRaid.teamId,
+      // Denormalised from the resolved team rather than the create result so it is never undefined.
+      teamId: targetTeamId,
       userId,
       guildId: interaction.guild!.id,
       username: member?.displayName || 'Unknown',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,6 +2,7 @@ import {
   SlashCommandBuilder,
   CommandInteraction,
   ChatInputCommandInteraction,
+  EmbedBuilder,
   PermissionFlagsBits,
 } from 'discord.js';
 import prisma from '../database/client';
@@ -17,6 +18,33 @@ import { gateFeature } from '../middleware/premiumGate';
 import { getTier, hasFeature } from '../services/entitlementService';
 import { t } from '../utils/localization';
 import { VERSION } from '../utils/version';
+import { addTeamOption, getTeamLabel, resolveTeam, TEAM_OPTION_NAME } from '../utils/teamContext';
+
+/**
+ * Names the team an embed's numbers belong to, right in its title.
+ *
+ * `getTeamLabel()` yields `null` on single-team guilds, so their titles stay byte-for-byte
+ * identical to the pre-multi-team wording; only guilds that actually run several teams pay
+ * for the extra clarity.
+ * @param guildId Discord guild ID
+ * @param teamId Team the figures were scoped to, or the raid's own team
+ * @param embed Embed to amend in place
+ */
+async function appendTeamToTitle(
+  guildId: string,
+  teamId: string | null | undefined,
+  embed: EmbedBuilder,
+): Promise<void> {
+  const label = await getTeamLabel(guildId, teamId);
+  if (label) {
+    embed.setTitle(`${embed.data.title} — ${label}`);
+  }
+}
+
+/** Reads the shared optional `team` option; `undefined` when it was not supplied. */
+function getTeamOption(interaction: ChatInputCommandInteraction): string | undefined {
+  return interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
+}
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -34,7 +62,7 @@ const command: Command = {
         )
     )
     .addSubcommand((subcommand) =>
-      subcommand
+      addTeamOption(subcommand
         .setName('guild')
         .setDescription('View guild-wide attendance statistics')
         .addStringOption((option) =>
@@ -47,15 +75,15 @@ const command: Command = {
               { name: 'All time', value: 'all' }
             )
             .setRequired(false)
-        )
+        ))
     )
     .addSubcommand((subcommand) =>
-      subcommand
+      addTeamOption(subcommand
         .setName('status')
-        .setDescription('View all upcoming raids at a glance')
+        .setDescription('View all upcoming raids at a glance'))
     )
     .addSubcommand((subcommand) =>
-      subcommand
+      addTeamOption(subcommand
         .setName('attendance')
         .setDescription('View a player\'s attendance history and reliability')
         .addUserOption((option) =>
@@ -74,7 +102,7 @@ const command: Command = {
               { name: 'All time', value: 'all' }
             )
             .setRequired(false)
-        )
+        ))
     )
     .addSubcommand((subcommand) =>
       subcommand
@@ -144,6 +172,9 @@ async function handleRaidStats(interaction: ChatInputCommandInteraction) {
   const raidInfo = { id: raid.id, description: raid.description };
   const embed = formatRaidStatsEmbed(raidInfo, stats, raid.guild.language || 'en');
 
+  // No `team` option here — the raid ID already pins the team; just name it on multi-team guilds.
+  await appendTeamToTitle(interaction.guild.id, raid.teamId, embed);
+
   await interaction.editReply({ embeds: [embed] });
 }
 
@@ -173,10 +204,20 @@ async function handleGuildStats(interaction: ChatInputCommandInteraction) {
 
   const period = interaction.options.get('period', false)?.value as string || 'month';
 
+  const teamOption = getTeamOption(interaction);
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError) {
+    await interaction.editReply({
+      content: t(guildData.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
+
   const startDate = getStartDate(period);
   const raids = await prisma.raid.findMany({
     where: {
       guildId: interaction.guild.id,
+      teamId: team.id,
       raidDate: { gte: startDate },
     },
     include: { attendance: true },
@@ -184,6 +225,8 @@ async function handleGuildStats(interaction: ChatInputCommandInteraction) {
 
   const stats = calculateGuildStats(raids);
   const embed = formatGuildStatsEmbed(stats, period, guildData.language || 'en');
+
+  await appendTeamToTitle(interaction.guild.id, team.id, embed);
 
   await interaction.editReply({ embeds: [embed] });
 }
@@ -215,10 +258,25 @@ async function handleStatusCommand(interaction: ChatInputCommandInteraction) {
 
   await interaction.deferReply({ ephemeral: true });
 
+  // Fetched before the query so an unknown team name can be reported in the guild's language
+  const guildData = await prisma.guild.findUnique({
+    where: { id: interaction.guild.id },
+  });
+
+  const teamOption = getTeamOption(interaction);
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError) {
+    await interaction.editReply({
+      content: t(guildData?.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
+
   const now = new Date();
   const raids = await prisma.raid.findMany({
     where: {
       guildId: interaction.guild.id,
+      teamId: team.id,
       status: 'open',
       raidDate: {
         gte: now,
@@ -233,11 +291,9 @@ async function handleStatusCommand(interaction: ChatInputCommandInteraction) {
     },
   });
 
-  const guildData = await prisma.guild.findUnique({
-    where: { id: interaction.guild.id },
-  });
-
   const embed = formatStatusEmbed(raids, guildData?.language || 'en');
+
+  await appendTeamToTitle(interaction.guild.id, team.id, embed);
 
   await interaction.editReply({ embeds: [embed] });
 }
@@ -268,12 +324,22 @@ async function handleAttendanceCommand(interaction: ChatInputCommandInteraction)
   }
 
   const lang = guildData.language || 'en';
+
+  const teamOption = getTeamOption(interaction);
+  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  if (teamError) {
+    await interaction.editReply({
+      content: t(lang, 'teamNotFound', { name: teamOption ?? '' }),
+    });
+    return;
+  }
+
   const tier = await getTier(interaction.guild.id);
   const hasFullHistory = hasFeature(tier, 'stats.full_history');
 
-  const playerStats = await calculatePlayerStats(player.id, interaction.guild.id, period);
-  const roleDistribution = await getPlayerRoleDistribution(player.id, interaction.guild.id);
-  let history = await getPlayerAttendanceHistory(player.id, interaction.guild.id, period);
+  const playerStats = await calculatePlayerStats(player.id, interaction.guild.id, period, team.id);
+  const roleDistribution = await getPlayerRoleDistribution(player.id, interaction.guild.id, team.id);
+  let history = await getPlayerAttendanceHistory(player.id, interaction.guild.id, period, team.id);
 
   // Cap history for free tier
   const FREE_HISTORY_LIMIT = 10;
@@ -283,6 +349,8 @@ async function handleAttendanceCommand(interaction: ChatInputCommandInteraction)
   }
 
   const embed = formatAttendanceEmbed(player.displayName || player.username || 'Unknown', playerStats, roleDistribution, history, period, lang);
+
+  await appendTeamToTitle(interaction.guild.id, team.id, embed);
 
   if (wasCapped) {
     const upsell = t(lang, 'premiumAttendanceCapped', { count: FREE_HISTORY_LIMIT });
@@ -337,6 +405,9 @@ async function handleSuggestCommand(interaction: ChatInputCommandInteraction) {
   const likelihood = calculateSuccessLikelihood(raid.attendance);
 
   const embed = formatCompositionEmbed(raid.description || 'Raid', composition, gaps, suggestions, likelihood, suggestLang);
+
+  // Like `stats raid`, this analyses one raid by ID — the team follows from the raid itself.
+  await appendTeamToTitle(interaction.guild.id, raid.teamId, embed);
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -14,7 +14,7 @@ import { calculatePlayerStats, getPlayerRoleDistribution, getPlayerAttendanceHis
 import { formatAttendanceEmbed } from '../utils/attendanceFormatter';
 import { analyzeRaidComposition, findCompositionGaps, suggestPlayerSwaps, calculateSuccessLikelihood } from '../utils/compositionAnalyzer';
 import { formatCompositionEmbed } from '../utils/compositionFormatter';
-import { gateFeature } from '../middleware/premiumGate';
+import { gateFeature, freeTierHint } from '../middleware/premiumGate';
 import { getTier, hasFeature } from '../services/entitlementService';
 import { t } from '../utils/localization';
 import { VERSION } from '../utils/version';
@@ -228,7 +228,8 @@ async function handleGuildStats(interaction: ChatInputCommandInteraction) {
 
   await appendTeamToTitle(interaction.guild.id, team.id, embed);
 
-  await interaction.editReply({ embeds: [embed] });
+  const hint = await freeTierHint(interaction.guildId, guildData.language || 'en');
+  await interaction.editReply({ embeds: [embed], content: hint || undefined });
 }
 
 function getStartDate(period: string): Date {
@@ -295,7 +296,8 @@ async function handleStatusCommand(interaction: ChatInputCommandInteraction) {
 
   await appendTeamToTitle(interaction.guild.id, team.id, embed);
 
-  await interaction.editReply({ embeds: [embed] });
+  const hint = await freeTierHint(interaction.guildId, guildData?.language || 'en');
+  await interaction.editReply({ embeds: [embed], content: hint || undefined });
 }
 
 async function handleAttendanceCommand(interaction: ChatInputCommandInteraction) {
@@ -357,7 +359,8 @@ async function handleAttendanceCommand(interaction: ChatInputCommandInteraction)
     embed.setFooter({ text: `${upsell} | v${VERSION}` });
   }
 
-  await interaction.editReply({ embeds: [embed] });
+  const hint = await freeTierHint(interaction.guildId, lang);
+  await interaction.editReply({ embeds: [embed], content: hint || undefined });
 }
 
 async function handleSuggestCommand(interaction: ChatInputCommandInteraction) {

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -1,0 +1,202 @@
+import {
+  SlashCommandBuilder,
+  CommandInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  PermissionFlagsBits,
+} from 'discord.js';
+import prisma from '../database/client';
+import { Command } from '../types';
+import { VERSION } from '../utils/version';
+import { t } from '../utils/localization';
+import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
+import { canCreateAdditionalTeam, getTier } from '../services/entitlementService';
+import {
+  countTeams,
+  createTeam,
+  deleteTeam,
+  getTeamByName,
+  listTeams,
+  DuplicateTeamNameError,
+} from '../services/teamService';
+
+/** Discord option limit we mirror for team names. */
+const MAX_TEAM_NAME_LENGTH = 50;
+
+/**
+ * Cascade warning appended to the delete confirmation.
+ * Kept local (not in `Translations`) because it is specific to this one response.
+ */
+const DELETE_CASCADE_NOTE: Record<string, string> = {
+  en: 'All raids of this team were deleted as well.',
+  de: 'Alle Raids dieses Teams wurden ebenfalls gelöscht.',
+};
+
+const command: Command = {
+  data: new SlashCommandBuilder()
+    .setName('team')
+    .setDescription('Manage raid teams for this server')
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('create')
+        .setDescription('Create a new team')
+        .addStringOption((option) =>
+          option
+            .setName('name')
+            .setDescription('Name of the new team (max 50 characters)')
+            .setRequired(true)
+            .setMaxLength(MAX_TEAM_NAME_LENGTH)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand.setName('list').setDescription('List all teams of this server')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('delete')
+        .setDescription('Delete a team and all of its raids')
+        .addStringOption((option) =>
+          option
+            .setName('name')
+            .setDescription('Name of the team to delete')
+            .setRequired(true)
+        )
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator) as SlashCommandBuilder,
+
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand()) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'create') {
+      await handleCreateTeam(interaction);
+    } else if (subcommand === 'list') {
+      await handleListTeams(interaction);
+    } else if (subcommand === 'delete') {
+      await handleDeleteTeam(interaction);
+    }
+  },
+};
+
+/** Guild language, defaulting to English when the guild has no record yet. */
+async function getGuildLanguage(guildId: string): Promise<string> {
+  const guildData = await prisma.guild.findUnique({
+    where: { id: guildId },
+    select: { language: true },
+  });
+  return guildData?.language || 'en';
+}
+
+async function handleCreateTeam(interaction: ChatInputCommandInteraction) {
+  if (!interaction.guild) {
+    await interaction.reply({
+      content: '❌ This command can only be used in a server!',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const guildId = interaction.guild.id;
+  const lang = await getGuildLanguage(guildId);
+  const name = interaction.options.getString('name', true).trim();
+
+  if (!name || name.length > MAX_TEAM_NAME_LENGTH) {
+    await interaction.reply({ content: t(lang, 'teamInvalidName'), ephemeral: true });
+    return;
+  }
+
+  // Gate before deferring so gateFeature can reply with the upsell embed directly.
+  const currentCount = await countTeams(guildId);
+  if (!(await canCreateAdditionalTeam(guildId, currentCount))) {
+    await gateFeature(interaction, 'team.multi', lang);
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const team = await createTeam(guildId, name, interaction.user.id);
+    await interaction.editReply({ content: t(lang, 'teamCreated', { name: team.name }) });
+  } catch (error) {
+    if (error instanceof DuplicateTeamNameError) {
+      await interaction.editReply({ content: t(lang, 'teamAlreadyExists', { name }) });
+      return;
+    }
+    throw error;
+  }
+}
+
+async function handleListTeams(interaction: ChatInputCommandInteraction) {
+  if (!interaction.guild) {
+    await interaction.reply({
+      content: '❌ This command can only be used in a server!',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const guildId = interaction.guild.id;
+  const lang = await getGuildLanguage(guildId);
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const teams = await listTeams(guildId);
+
+  const lines = await Promise.all(
+    teams.map(async (team) => {
+      const raidCount = await prisma.raid.count({ where: { teamId: team.id } });
+      const entry = t(lang, 'teamListEntry', { name: team.name, count: raidCount });
+      return team.isDefault ? `${entry} _(${t(lang, 'teamDefaultBadge')})_` : entry;
+    })
+  );
+
+  const embed = new EmbedBuilder()
+    .setTitle(t(lang, 'teamListTitle'))
+    .setColor(0x00ae86)
+    .setDescription(lines.length > 0 ? lines.join('\n') : t(lang, 'teamListEmpty'))
+    .setFooter({ text: `RaidPresence • v${VERSION}` })
+    .setTimestamp();
+
+  // Free guilds sitting at their single default team get a low-key upgrade nudge.
+  const tier = await getTier(guildId);
+  const content = teams.length <= 1 && tier === 'FREE' ? premiumFooterHint(lang) : undefined;
+
+  await interaction.editReply({ embeds: [embed], ...(content ? { content } : {}) });
+}
+
+async function handleDeleteTeam(interaction: ChatInputCommandInteraction) {
+  if (!interaction.guild) {
+    await interaction.reply({
+      content: '❌ This command can only be used in a server!',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const guildId = interaction.guild.id;
+  const lang = await getGuildLanguage(guildId);
+  const name = interaction.options.getString('name', true).trim();
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const team = await getTeamByName(guildId, name);
+
+  if (!team) {
+    await interaction.editReply({ content: t(lang, 'teamNotFound', { name }) });
+    return;
+  }
+
+  if (team.isDefault) {
+    await interaction.editReply({ content: t(lang, 'teamCannotDeleteDefault') });
+    return;
+  }
+
+  await deleteTeam(team.id);
+
+  await interaction.editReply({
+    content: `${t(lang, 'teamDeleted', { name: team.name })}\n${DELETE_CASCADE_NOTE[lang] || DELETE_CASCADE_NOTE.en}`,
+  });
+}
+
+export default command;

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -9,8 +9,8 @@ import prisma from '../database/client';
 import { Command } from '../types';
 import { VERSION } from '../utils/version';
 import { t } from '../utils/localization';
-import { gateFeature, premiumFooterHint } from '../middleware/premiumGate';
-import { canCreateAdditionalTeam, getTier } from '../services/entitlementService';
+import { gateFeature, freeTierHint } from '../middleware/premiumGate';
+import { canCreateAdditionalTeam } from '../services/entitlementService';
 import {
   countTeams,
   createTeam,
@@ -158,11 +158,10 @@ async function handleListTeams(interaction: ChatInputCommandInteraction) {
     .setFooter({ text: `RaidPresence • v${VERSION}` })
     .setTimestamp();
 
-  // Free guilds sitting at their single default team get a low-key upgrade nudge.
-  const tier = await getTier(guildId);
-  const content = teams.length <= 1 && tier === 'FREE' ? premiumFooterHint(lang) : undefined;
+  // Free guilds get the shared low-key upgrade nudge; premium replies stay unchanged.
+  const hint = await freeTierHint(interaction.guildId, lang);
 
-  await interaction.editReply({ embeds: [embed], ...(content ? { content } : {}) });
+  await interaction.editReply({ embeds: [embed], ...(hint ? { content: hint } : {}) });
 }
 
 async function handleDeleteTeam(interaction: ChatInputCommandInteraction) {

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -10,14 +10,15 @@ import { Command } from '../types';
 import { VERSION } from '../utils/version';
 import { t } from '../utils/localization';
 import { gateFeature, freeTierHint } from '../middleware/premiumGate';
-import { canCreateAdditionalTeam } from '../services/entitlementService';
+import { canCreateAdditionalTeam, teamLimitFor } from '../services/entitlementService';
 import {
   countTeams,
-  createTeam,
+  createTeamWithinLimit,
   deleteTeam,
   getTeamByName,
   listTeams,
   DuplicateTeamNameError,
+  TeamLimitReachedError,
 } from '../services/teamService';
 
 /** Discord option limit we mirror for team names. */
@@ -113,14 +114,23 @@ async function handleCreateTeam(interaction: ChatInputCommandInteraction) {
     return;
   }
 
+  // The pre-check above is only the fast path for the common case; the limit itself is
+  // enforced inside the create transaction, so two parallel calls can never both pass.
+  const maxTeams = await teamLimitFor(guildId);
+
   await interaction.deferReply({ ephemeral: true });
 
   try {
-    const team = await createTeam(guildId, name, interaction.user.id);
+    const team = await createTeamWithinLimit(guildId, name, interaction.user.id, maxTeams);
     await interaction.editReply({ content: t(lang, 'teamCreated', { name: team.name }) });
   } catch (error) {
     if (error instanceof DuplicateTeamNameError) {
       await interaction.editReply({ content: t(lang, 'teamAlreadyExists', { name }) });
+      return;
+    }
+    if (error instanceof TeamLimitReachedError) {
+      // Lost the race against a concurrent create: same friendly upsell, never a raw DB error.
+      await gateFeature(interaction, 'team.multi', lang);
       return;
     }
     throw error;

--- a/src/database/__mocks__/client.ts
+++ b/src/database/__mocks__/client.ts
@@ -31,6 +31,16 @@ const prisma: Record<string, any> = {
     updateMany: jest.fn(),
     upsert: jest.fn(),
   },
+  team: {
+    // Default team resolution succeeds out of the box so raid fixtures get a teamId
+    findFirst: jest.fn().mockResolvedValue({ id: 'team-default', guildId: 'guild-1', name: 'Main', isDefault: true, createdBy: 'system' }),
+    findUnique: jest.fn(),
+    findMany: jest.fn().mockResolvedValue([]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+  },
   userRolePreference: {
     findMany: jest.fn().mockResolvedValue([]),
     findUnique: jest.fn(),

--- a/src/database/__mocks__/client.ts
+++ b/src/database/__mocks__/client.ts
@@ -6,6 +6,7 @@ const prisma: Record<string, any> = {
     update: jest.fn(),
     delete: jest.fn(),
     deleteMany: jest.fn(),
+    count: jest.fn().mockResolvedValue(0),
   },
   raidAttendance: {
     findMany: jest.fn(),

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -4,6 +4,7 @@ import raidCommand from './commands/raid';
 import configCommand from './commands/config';
 import setupCommand from './commands/setup';
 import statsCommand from './commands/stats';
+import teamCommand from './commands/team';
 
 config();
 
@@ -12,6 +13,7 @@ const commands = [
   configCommand.data.toJSON(),
   setupCommand.data.toJSON(),
   statsCommand.data.toJSON(),
+  teamCommand.data.toJSON(),
 ];
 
 const rest = new REST().setToken(process.env.DISCORD_TOKEN!);

--- a/src/events/__tests__/attendance-team.test.ts
+++ b/src/events/__tests__/attendance-team.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { handleButton, handleModalSubmit } from '../buttonHandler';
+import { handleSelectMenu } from '../selectHandler';
+import prisma from '../../database/client';
+import { ButtonInteraction, ModalSubmitInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+jest.mock('../../database/client');
+jest.mock('../../commands/raid', () => ({
+  createRaidEmbed: jest.fn(() => Promise.resolve({})),
+}));
+jest.mock('../../services/entitlementService', () => ({
+  getTier: jest.fn(() => Promise.resolve('FREE')),
+  hasFeature: jest.fn(() => false),
+}));
+
+const raidId = 'raid-team-1';
+const userId = 'user-1';
+const guildId = 'guild-1';
+
+/**
+ * RPTIER Phase 4: attendance interactions must keep the denormalized
+ * RaidAttendance.teamId in sync with the raid it belongs to.
+ */
+describe('Attendance interactions - team consistency', () => {
+  const mockRaid = {
+    id: raidId,
+    guildId,
+    teamId: 'team-42',
+    status: 'open',
+    messageId: 'message-1',
+    channelId: 'channel-1',
+    roles: '',
+    guild: { language: 'en' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.raid.findUnique as jest.Mock<any>).mockResolvedValue(mockRaid);
+  });
+
+  const makeButtonInteraction = (subAction: string): Partial<ButtonInteraction> =>
+    ({
+      customId: `raid_${subAction}_${raidId}`,
+      guildId,
+      user: { id: userId } as any,
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+      message: { edit: jest.fn() } as any,
+      client: { channels: { fetch: jest.fn() } } as any,
+    }) as any;
+
+  describe('buttonHandler', () => {
+    it.each([
+      ['optin', 'attending'],
+      ['late', 'late'],
+      ['optout', 'opted_out'],
+    ])('writes the raid team when handling %s', async (subAction, expectedStatus) => {
+      (prisma.raidAttendance.findUnique as jest.Mock<any>).mockResolvedValueOnce({
+        status: 'unknown',
+      });
+
+      await handleButton(makeButtonInteraction(subAction) as ButtonInteraction);
+
+      const call = (prisma.raidAttendance.update as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data.status).toBe(expectedStatus);
+      expect(call.data.teamId).toBe('team-42');
+    });
+
+    it('omits teamId when the raid has none (pre-migration data)', async () => {
+      (prisma.raid.findUnique as jest.Mock<any>).mockResolvedValue({ ...mockRaid, teamId: null });
+      (prisma.raidAttendance.findUnique as jest.Mock<any>).mockResolvedValueOnce({
+        status: 'unknown',
+      });
+
+      await handleButton(makeButtonInteraction('optin') as ButtonInteraction);
+
+      const call = (prisma.raidAttendance.update as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data).not.toHaveProperty('teamId');
+    });
+  });
+
+  describe('opt-out reason modal', () => {
+    it('writes the raid team alongside the reason', async () => {
+      (prisma.raidAttendance.findUnique as jest.Mock<any>).mockResolvedValueOnce({
+        status: 'attending',
+      });
+
+      const interaction = {
+        customId: `optout_reason_${raidId}_${userId}`,
+        user: { id: userId },
+        fields: { getTextInputValue: jest.fn(() => 'Work emergency') },
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        client: { channels: { fetch: jest.fn() } },
+      } as any;
+
+      await handleModalSubmit(interaction as ModalSubmitInteraction);
+
+      const call = (prisma.raidAttendance.update as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data.optoutReason).toBe('Work emergency');
+      expect(call.data.teamId).toBe('team-42');
+    });
+  });
+
+  describe('selectHandler', () => {
+    const makeSelectInteraction = (): Partial<StringSelectMenuInteraction> =>
+      ({
+        customId: `spec_select_${raidId}_Warrior`,
+        values: ['Arms'],
+        user: { id: userId } as any,
+        guild: {
+          id: guildId,
+          members: {
+            fetch: jest.fn(() =>
+              Promise.resolve({ displayName: 'Player', roles: { cache: new Map() } })
+            ),
+          },
+        } as any,
+        deferUpdate: jest.fn(),
+        editReply: jest.fn(),
+        client: { channels: { fetch: jest.fn() } } as any,
+      }) as any;
+
+    it('writes the raid team when saving class/spec', async () => {
+      await handleSelectMenu(makeSelectInteraction() as StringSelectMenuInteraction);
+
+      const call = (prisma.raidAttendance.update as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data.wowClass).toBe('Warrior');
+      expect(call.data.wowSpec).toBe('Arms');
+      expect(call.data.teamId).toBe('team-42');
+    });
+
+    it('omits teamId when the raid has none (pre-migration data)', async () => {
+      (prisma.raid.findUnique as jest.Mock<any>).mockResolvedValue({ ...mockRaid, teamId: null });
+
+      await handleSelectMenu(makeSelectInteraction() as StringSelectMenuInteraction);
+
+      const call = (prisma.raidAttendance.update as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data).not.toHaveProperty('teamId');
+    });
+  });
+});

--- a/src/events/buttonHandler.ts
+++ b/src/events/buttonHandler.ts
@@ -109,7 +109,14 @@ async function handleDirectOptOut(interaction: ButtonInteraction, raidId: string
 
   await prisma.raidAttendance.update({
     where: { raidId_userId: { raidId, userId: interaction.user.id } },
-    data: { status: 'opted_out', respondedAt: new Date(), optoutReason: null, notedAt: null },
+    data: {
+      status: 'opted_out',
+      respondedAt: new Date(),
+      optoutReason: null,
+      notedAt: null,
+      // Keep the denormalized team in sync with the raid (RPTIER Phase 4)
+      ...(raid.teamId ? { teamId: raid.teamId } : {}),
+    },
   });
 
   await interaction.editReply({ content: trans.optoutReasonSubmitted });
@@ -175,6 +182,8 @@ async function handleOptIn(interaction: ButtonInteraction, raidId: string) {
     data: {
       status: 'attending',
       respondedAt: new Date(),
+      // Keep the denormalized team in sync with the raid (RPTIER Phase 4)
+      ...(raid.teamId ? { teamId: raid.teamId } : {}),
     },
   });
 
@@ -245,6 +254,8 @@ async function handleRunningLate(interaction: ButtonInteraction, raidId: string)
     data: {
       status: 'late',
       respondedAt: new Date(),
+      // Keep the denormalized team in sync with the raid (RPTIER Phase 4)
+      ...(raid.teamId ? { teamId: raid.teamId } : {}),
     },
   });
 
@@ -383,6 +394,8 @@ async function handleOptOutReasonSubmit(interaction: ModalSubmitInteraction) {
       respondedAt: new Date(),
       optoutReason: reason || null,
       notedAt: reason ? new Date() : null,
+      // Keep the denormalized team in sync with the raid (RPTIER Phase 4)
+      ...(raid.teamId ? { teamId: raid.teamId } : {}),
     },
   });
 

--- a/src/events/selectHandler.ts
+++ b/src/events/selectHandler.ts
@@ -128,6 +128,8 @@ async function handleSpecSelect(interaction: StringSelectMenuInteraction, raidId
     data: {
       wowClass: selectedClass,
       wowSpec: selectedSpec,
+      // Keep the denormalized team in sync with the raid (RPTIER Phase 4)
+      ...(raid?.teamId ? { teamId: raid.teamId } : {}),
     },
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerEntitlementHandlers } from './events/entitlementHandler';
 import { syncEntitlementsOnStartup, grantTrialIfEligible, TRIAL_DAYS } from './services/entitlementService';
 import { localeToLanguage } from './utils/localization';
 import { buildWelcomeEmbed } from './utils/welcomeEmbed';
+import { getDefaultTeam } from './services/teamService';
 
 config();
 
@@ -79,6 +80,14 @@ client.once(Events.ClientReady, async (c) => {
         timezoneOffset: timezoneOffset,
       },
     });
+
+    // Make sure every guild owns its default "Main" team. Never abort startup
+    // over this — the team is created lazily on first raid creation anyway.
+    try {
+      await getDefaultTeam(guildId);
+    } catch (error) {
+      console.error(`❌ Failed to ensure default team for ${guild.name}:`, error);
+    }
 
     // Log auto-detection
     if (shouldSetTimezone && detectedTimezone !== null) {
@@ -160,6 +169,13 @@ client.on(Events.GuildCreate, async (guild) => {
       timezoneOffset: timezoneOffset,
     },
   });
+
+  // Make sure the guild owns its default "Main" team right away.
+  try {
+    await getDefaultTeam(guild.id);
+  } catch (error) {
+    console.error(`❌ Failed to ensure default team for ${guild.name}:`, error);
+  }
 
   // Auto-grant a one-time 14-day Premium trial to brand-new servers.
   let trialGranted = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,12 @@ import raidCommand from './commands/raid';
 import configCommand from './commands/config';
 import setupCommand from './commands/setup';
 import statsCommand from './commands/stats';
+import teamCommand from './commands/team';
 client.commands.set(raidCommand.data.name, raidCommand);
 client.commands.set(configCommand.data.name, configCommand);
 client.commands.set(setupCommand.data.name, setupCommand);
 client.commands.set(statsCommand.data.name, statsCommand);
+client.commands.set(teamCommand.data.name, teamCommand);
 
 // Ready event
 client.once(Events.ClientReady, async (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,12 @@ import { syncEntitlementsOnStartup, grantTrialIfEligible, TRIAL_DAYS } from './s
 import { localeToLanguage } from './utils/localization';
 import { buildWelcomeEmbed } from './utils/welcomeEmbed';
 import { getDefaultTeam } from './services/teamService';
+import { TEAM_OPTION_NAME } from './utils/teamContext';
 
 config();
+
+/** Commands that expose the shared, autocompleted `team` option. */
+const TEAM_AUTOCOMPLETE_COMMANDS = new Set(['raid', 'stats', 'team']);
 
 const client = new Client({
   intents: [
@@ -131,6 +135,21 @@ client.on(Events.InteractionCreate, async (interaction) => {
         await interaction.followUp(errorMessage);
       } else {
         await interaction.reply(errorMessage);
+      }
+    }
+  } else if (interaction.isAutocomplete()) {
+    // Shared `team` option autocomplete — every team-aware command uses the same handler.
+    const focused = interaction.options.getFocused(true);
+
+    if (
+      TEAM_AUTOCOMPLETE_COMMANDS.has(interaction.commandName) &&
+      focused.name === TEAM_OPTION_NAME
+    ) {
+      try {
+        const { teamAutocomplete } = await import('./utils/teamContext');
+        await teamAutocomplete(interaction);
+      } catch (error) {
+        console.error('Error handling team autocomplete:', error);
       }
     }
   } else if (interaction.isButton()) {

--- a/src/middleware/premiumGate.ts
+++ b/src/middleware/premiumGate.ts
@@ -107,8 +107,12 @@ export async function gateFeature(
 
   const embed = premiumUpsellEmbed(feature, tier, FEATURE_TIERS[feature], language);
 
-  if (interaction.replied || interaction.deferred) {
+  if (interaction.replied) {
     await interaction.followUp({ embeds: [embed], ephemeral: true });
+  } else if (interaction.deferred) {
+    // A pending deferral must be resolved, otherwise the "thinking…" placeholder never
+    // goes away and the upsell shows up as a second, orphaned message.
+    await interaction.editReply({ embeds: [embed] });
   } else {
     await interaction.reply({ embeds: [embed], ephemeral: true });
   }

--- a/src/middleware/premiumGate.ts
+++ b/src/middleware/premiumGate.ts
@@ -73,6 +73,21 @@ export function premiumFooterHint(language: string): string {
 }
 
 /**
+ * Free-tier suffix for message content: the footer hint prefixed with a newline
+ * when the guild is on FREE, otherwise an empty string. Lets any call site do
+ * `content + await freeTierHint(interaction.guildId, lang)` without changing the
+ * response for premium guilds.
+ */
+export async function freeTierHint(guildId: string | null, language: string): Promise<string> {
+  if (!guildId) return '';
+
+  const tier = await getTier(guildId);
+  if (tier !== 'FREE') return '';
+
+  return `\n${premiumFooterHint(language)}`;
+}
+
+/**
  * Checks if a guild has access to a premium feature.
  * If blocked, sends an ephemeral upsell embed and returns false.
  */

--- a/src/middleware/premiumGate.ts
+++ b/src/middleware/premiumGate.ts
@@ -21,6 +21,7 @@ const FEATURE_NAME_KEYS: Record<PremiumFeature, keyof Translations> = {
   'stats.full_history': 'featureStatsFullHistory',
   'stats.analytics': 'featureStatsAnalytics',
   'stats.export': 'featureStatsExport',
+  'team.multi': 'featureTeamMulti',
 };
 
 /** Localized display name for a tier (e.g. "Premium"). */

--- a/src/middleware/premiumGate.ts
+++ b/src/middleware/premiumGate.ts
@@ -58,6 +58,8 @@ export function premiumUpsellEmbed(
     .addFields(
       { name: t(language, 'premiumUpsellCurrentPlan'), value: tierName(currentTier, language), inline: true },
       { name: t(language, 'premiumUpsellRequiredPlan'), value: requiredTierName, inline: true },
+      // Perks list so every upsell sells multi-team, regardless of which feature triggered it.
+      { name: `💎 ${requiredTierName}`, value: t(language, 'premiumUpsellPerks'), inline: false },
     )
     .setFooter({ text: `RaidPresence • v${VERSION}` });
 }

--- a/src/middleware/premiumGate.ts
+++ b/src/middleware/premiumGate.ts
@@ -6,10 +6,9 @@ import { VERSION } from '../utils/version';
 /** Gold accent used across all premium surfaces. */
 export const PREMIUM_COLOR = 0xf1c40f;
 
-const TIER_NAME_KEYS: Record<PremiumTier, 'premiumTierFree' | 'premiumTierPremium' | 'premiumTierPro'> = {
+const TIER_NAME_KEYS: Record<PremiumTier, 'premiumTierFree' | 'premiumTierPremium'> = {
   FREE: 'premiumTierFree',
   PREMIUM: 'premiumTierPremium',
-  PRO: 'premiumTierPro',
 };
 
 /** Feature → localization key for its human-readable display name. */

--- a/src/services/entitlementService.ts
+++ b/src/services/entitlementService.ts
@@ -21,14 +21,13 @@ export const FEATURE_TIERS: Record<PremiumFeature, PremiumTier> = {
   'raid.recurring': 'PREMIUM',
   'stats.full_history': 'PREMIUM',
   'stats.analytics': 'PREMIUM',
-  'raid.template': 'PRO',
-  'stats.export': 'PRO',
-  'raid.integrations': 'PRO',
+  'raid.template': 'PREMIUM',
+  'stats.export': 'PREMIUM',
+  'raid.integrations': 'PREMIUM',
 };
 
 /** Maps a Discord SKU ID to its premium tier. */
 export function skuToTier(skuId: string): PremiumTier | null {
-  if (skuId === process.env.DISCORD_SKU_PRO) return 'PRO';
   if (skuId === process.env.DISCORD_SKU_PREMIUM) return 'PREMIUM';
   return null;
 }
@@ -36,7 +35,6 @@ export function skuToTier(skuId: string): PremiumTier | null {
 const TIER_RANK: Record<PremiumTier, number> = {
   FREE: 0,
   PREMIUM: 1,
-  PRO: 2,
 };
 
 const FREE_WEEKLY_RAID_LIMIT = 5;
@@ -131,7 +129,7 @@ export function hasFeature(tier: PremiumTier, feature: PremiumFeature): boolean 
 
 /**
  * Atomically checks and consumes a weekly raid slot for a guild.
- * Free tier: 5 raids/week. Premium/Pro: unlimited.
+ * Free tier: 5 raids/week. Premium: unlimited.
  * Auto-resets the counter when the 7-day window expires.
  *
  * Returns { allowed, remaining } — if allowed, the count has already been incremented.

--- a/src/services/entitlementService.ts
+++ b/src/services/entitlementService.ts
@@ -12,7 +12,8 @@ export type PremiumFeature =
   | 'raid.integrations'
   | 'stats.full_history'
   | 'stats.analytics'
-  | 'stats.export';
+  | 'stats.export'
+  | 'team.multi';
 
 /** Feature → minimum tier required */
 export const FEATURE_TIERS: Record<PremiumFeature, PremiumTier> = {
@@ -24,6 +25,7 @@ export const FEATURE_TIERS: Record<PremiumFeature, PremiumTier> = {
   'raid.template': 'PREMIUM',
   'stats.export': 'PREMIUM',
   'raid.integrations': 'PREMIUM',
+  'team.multi': 'PREMIUM',
 };
 
 /** Maps a Discord SKU ID to its premium tier. */
@@ -38,6 +40,9 @@ const TIER_RANK: Record<PremiumTier, number> = {
 };
 
 const FREE_WEEKLY_RAID_LIMIT = 5;
+
+/** Number of teams a FREE guild may have (just the default "Main" team). */
+export const FREE_TEAM_LIMIT = 1;
 
 /** In-memory tier cache with 30s TTL — keeps button interactions fast */
 const tierCache = new Map<string, { tier: PremiumTier; expiresAt: number }>();
@@ -125,6 +130,21 @@ export async function syncEntitlement(params: {
 export function hasFeature(tier: PremiumTier, feature: PremiumFeature): boolean {
   const requiredTier = FEATURE_TIERS[feature];
   return TIER_RANK[tier] >= TIER_RANK[requiredTier];
+}
+
+/**
+ * Checks whether a guild may create another team.
+ *
+ * PREMIUM guilds have unlimited teams. FREE guilds are capped at
+ * `FREE_TEAM_LIMIT` (the default "Main" team) — a second team is the
+ * upsell trigger for the `team.multi` feature.
+ */
+export async function canCreateAdditionalTeam(
+  guildId: string,
+  currentTeamCount: number,
+): Promise<boolean> {
+  if (hasFeature(await getTier(guildId), 'team.multi')) return true;
+  return currentTeamCount < FREE_TEAM_LIMIT;
 }
 
 /**

--- a/src/services/entitlementService.ts
+++ b/src/services/entitlementService.ts
@@ -148,6 +148,16 @@ export async function canCreateAdditionalTeam(
 }
 
 /**
+ * Total number of teams the guild's current tier allows, or `null` for unlimited.
+ *
+ * Handed to `createTeamWithinLimit()` so the limit is enforced inside the insert's
+ * transaction instead of only in the command's pre-check.
+ */
+export async function teamLimitFor(guildId: string): Promise<number | null> {
+  return hasFeature(await getTier(guildId), 'team.multi') ? null : FREE_TEAM_LIMIT;
+}
+
+/**
  * Atomically checks and consumes a weekly raid slot for a guild.
  * Free tier: 5 raids/week. Premium: unlimited.
  * Auto-resets the counter when the 7-day window expires.

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -1,0 +1,135 @@
+import { Prisma, type Team } from '@prisma/client';
+import prisma from '../database/client';
+
+export type { Team };
+
+/** Name of the auto-created default team every guild gets. */
+export const DEFAULT_TEAM_NAME = 'Main';
+
+/** Creator marker for auto-created default teams (no real Discord user behind it). */
+const SYSTEM_CREATOR = 'system';
+
+/** Thrown when a team name is already taken within the guild. */
+export class DuplicateTeamNameError extends Error {
+  constructor(public readonly guildId: string, public readonly name: string) {
+    super(`A team named "${name}" already exists in guild ${guildId}`);
+    this.name = 'DuplicateTeamNameError';
+  }
+}
+
+/** Thrown when an operation is attempted on the default team that is not allowed for it. */
+export class DefaultTeamProtectedError extends Error {
+  constructor(public readonly teamId: string) {
+    super(`Team ${teamId} is the default team and cannot be deleted`);
+    this.name = 'DefaultTeamProtectedError';
+  }
+}
+
+/** Thrown when the referenced team does not exist. */
+export class TeamNotFoundError extends Error {
+  constructor(public readonly teamId: string) {
+    super(`Team ${teamId} not found`);
+    this.name = 'TeamNotFoundError';
+  }
+}
+
+/** True when the error is a Prisma unique-constraint violation (P2002). */
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002'
+  );
+}
+
+/**
+ * Returns the guild's default team, creating it lazily when the guild has none yet.
+ *
+ * Idempotent under concurrency: two parallel calls for a fresh guild both attempt the
+ * create, the loser hits the `@@unique([guildId, name])` constraint (P2002) and re-reads
+ * the row the winner just wrote, so no duplicates are produced.
+ */
+export async function getDefaultTeam(guildId: string): Promise<Team> {
+  const existing = await prisma.team.findFirst({
+    where: { guildId, isDefault: true },
+  });
+  if (existing) return existing;
+
+  try {
+    return await prisma.team.create({
+      data: {
+        guildId,
+        name: DEFAULT_TEAM_NAME,
+        isDefault: true,
+        createdBy: SYSTEM_CREATOR,
+      },
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+
+    // Lost the race — the concurrent caller already created it.
+    const team = await prisma.team.findFirst({
+      where: { guildId, isDefault: true },
+    });
+    if (!team) throw error;
+    return team;
+  }
+}
+
+/** Lists all teams of a guild, default team first, then alphabetically by name. */
+export async function listTeams(guildId: string): Promise<Team[]> {
+  return prisma.team.findMany({
+    where: { guildId },
+    orderBy: [{ isDefault: 'desc' }, { name: 'asc' }],
+  });
+}
+
+/** Case-insensitive lookup of a team by name within a guild. */
+export async function getTeamByName(guildId: string, name: string): Promise<Team | null> {
+  return prisma.team.findFirst({
+    where: {
+      guildId,
+      name: { equals: name, mode: 'insensitive' },
+    },
+  });
+}
+
+/**
+ * Creates a non-default team.
+ *
+ * Pure data access — premium gating (team limits per tier) lives in the command layer.
+ * Throws {@link DuplicateTeamNameError} when the name is already taken in that guild.
+ */
+export async function createTeam(
+  guildId: string,
+  name: string,
+  createdBy: string,
+): Promise<Team> {
+  try {
+    return await prisma.team.create({
+      data: { guildId, name, isDefault: false, createdBy },
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      throw new DuplicateTeamNameError(guildId, name);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Deletes a team and — via the schema's cascade — its raids and attendance.
+ *
+ * The default team is protected: it is the fallback every guild needs, so deleting it
+ * would orphan the guild's raid creation path.
+ */
+export async function deleteTeam(teamId: string): Promise<void> {
+  const team = await prisma.team.findUnique({ where: { id: teamId } });
+  if (!team) throw new TeamNotFoundError(teamId);
+  if (team.isDefault) throw new DefaultTeamProtectedError(teamId);
+
+  await prisma.team.delete({ where: { id: teamId } });
+}
+
+/** Number of teams in a guild (including the default team). */
+export async function countTeams(guildId: string): Promise<number> {
+  return prisma.team.count({ where: { guildId } });
+}

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -82,6 +82,11 @@ export async function listTeams(guildId: string): Promise<Team[]> {
   });
 }
 
+/** Lookup of a team by its ID. Returns `null` when the team no longer exists. */
+export async function getTeamById(teamId: string): Promise<Team | null> {
+  return prisma.team.findUnique({ where: { id: teamId } });
+}
+
 /** Case-insensitive lookup of a team by name within a guild. */
 export async function getTeamByName(guildId: string, name: string): Promise<Team | null> {
   return prisma.team.findFirst({

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -33,6 +33,20 @@ export class TeamNotFoundError extends Error {
   }
 }
 
+/**
+ * Thrown when the guild already holds as many teams as its tier allows.
+ *
+ * Raised inside the serializable create transaction, so it is authoritative: at the
+ * moment of the (failed) insert the guild really was at its limit. The command layer
+ * translates it back into the regular premium upsell.
+ */
+export class TeamLimitReachedError extends Error {
+  constructor(public readonly guildId: string, public readonly limit: number) {
+    super(`Guild ${guildId} already has its maximum of ${limit} team(s)`);
+    this.name = 'TeamLimitReachedError';
+  }
+}
+
 /** True when the error is a Prisma unique-constraint violation (P2002). */
 function isUniqueConstraintError(error: unknown): boolean {
   return (
@@ -41,11 +55,36 @@ function isUniqueConstraintError(error: unknown): boolean {
 }
 
 /**
+ * True when the error is Postgres refusing to serialize a transaction (SQLSTATE 40001,
+ * surfaced by Prisma as P2034). Under `Serializable` this is the *expected* signal that
+ * a concurrent writer touched the rows we counted — the transaction simply has to be
+ * retried.
+ */
+function isSerializationFailure(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === 'P2034';
+  }
+  // Raw driver errors can slip through as unknown request errors carrying the SQLSTATE.
+  if (error instanceof Prisma.PrismaClientUnknownRequestError) {
+    return /40001|could not serialize/i.test(error.message);
+  }
+  return false;
+}
+
+/** How often a serialization failure is retried before we settle it with a plain count. */
+const MAX_SERIALIZATION_RETRIES = 2;
+
+/**
  * Returns the guild's default team, creating it lazily when the guild has none yet.
  *
  * Idempotent under concurrency: two parallel calls for a fresh guild both attempt the
  * create, the loser hits the `@@unique([guildId, name])` constraint (P2002) and re-reads
  * the row the winner just wrote, so no duplicates are produced.
+ *
+ * Also self-heals the one other way the P2002 can happen: a guild that owns a *non-default*
+ * team literally named "Main" (e.g. someone created it manually before the default team was
+ * provisioned) has no default team to re-read, and a plain retry would fail on the same
+ * conflict forever. That row is promoted to default instead.
  */
 export async function getDefaultTeam(guildId: string): Promise<Team> {
   const existing = await prisma.team.findFirst({
@@ -69,8 +108,19 @@ export async function getDefaultTeam(guildId: string): Promise<Team> {
     const team = await prisma.team.findFirst({
       where: { guildId, isDefault: true },
     });
-    if (!team) throw error;
-    return team;
+    if (team) return team;
+
+    // No default team, yet the name is taken: an existing non-default "Main" blocks us.
+    // Promote it rather than looping on a conflict we can never win.
+    const nameHolder = await prisma.team.findFirst({
+      where: { guildId, name: DEFAULT_TEAM_NAME },
+    });
+    if (!nameHolder) throw error;
+
+    return prisma.team.update({
+      where: { id: nameHolder.id },
+      data: { isDefault: true },
+    });
   }
 }
 
@@ -117,6 +167,65 @@ export async function createTeam(
       throw new DuplicateTeamNameError(guildId, name);
     }
     throw error;
+  }
+}
+
+/**
+ * Creates a non-default team, enforcing the guild's team limit atomically.
+ *
+ * `maxTeams` is the total number of teams the guild may hold, or `null` for unlimited
+ * (premium). The count and the insert run inside one `Serializable` transaction, so
+ * Postgres' predicate locks turn the read-then-write TOCTOU window into a serialization
+ * failure instead of an over-limit insert: of two concurrent `/team create` calls on a
+ * FREE guild, exactly one commits and the other is retried, sees the winner's row and
+ * throws {@link TeamLimitReachedError}.
+ *
+ * A partial unique index would be cheaper but cannot express this rule — the limit
+ * depends on `Guild.premiumTier`, i.e. on another table, which a Postgres index
+ * predicate may not reference (and a trigger reading it would need the same isolation
+ * to be race-free anyway).
+ *
+ * Throws {@link DuplicateTeamNameError} when the name is already taken in that guild and
+ * {@link TeamLimitReachedError} when the limit is (or has just become) exhausted.
+ */
+export async function createTeamWithinLimit(
+  guildId: string,
+  name: string,
+  createdBy: string,
+  maxTeams: number | null,
+): Promise<Team> {
+  // Unlimited tiers have no invariant to protect, so they skip the transaction entirely.
+  if (maxTeams === null) return createTeam(guildId, name, createdBy);
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          const currentCount = await tx.team.count({ where: { guildId } });
+          if (currentCount >= maxTeams) throw new TeamLimitReachedError(guildId, maxTeams);
+
+          return tx.team.create({
+            data: { guildId, name, isDefault: false, createdBy },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (error instanceof TeamLimitReachedError) throw error;
+      if (isUniqueConstraintError(error)) throw new DuplicateTeamNameError(guildId, name);
+
+      if (isSerializationFailure(error) && attempt < MAX_SERIALIZATION_RETRIES) continue;
+
+      if (isSerializationFailure(error)) {
+        // Retries exhausted. A concurrent create having taken the last slot is by far the
+        // likeliest cause, so check once more and report the limit rather than a DB error.
+        if ((await countTeams(guildId)) >= maxTeams) {
+          throw new TeamLimitReachedError(guildId, maxTeams);
+        }
+      }
+
+      throw error;
+    }
   }
 }
 

--- a/src/utils/__tests__/archiveManager.test.ts
+++ b/src/utils/__tests__/archiveManager.test.ts
@@ -373,6 +373,27 @@ describe('archiveManager', () => {
 
       expect(results).toHaveLength(0);
     });
+
+    it('should scope the query to a team when teamId is given', async () => {
+      (prisma.raid.findMany as any).mockResolvedValue([]);
+
+      await searchArchive({ guildId: 'guild-123', teamId: 'team-alts' });
+
+      expect(prisma.raid.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ guildId: 'guild-123', teamId: 'team-alts' }),
+        })
+      );
+    });
+
+    it('should stay guild-wide when no teamId is given', async () => {
+      (prisma.raid.findMany as any).mockResolvedValue([]);
+
+      await searchArchive({ guildId: 'guild-123' });
+
+      const where = (prisma.raid.findMany as any).mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('teamId');
+    });
   });
 
   describe('getArchiveStats', () => {
@@ -400,6 +421,28 @@ describe('archiveManager', () => {
       expect(stats.totalArchived).toBe(0);
       expect(stats.recentArchived).toBe(0);
       expect(prisma.raid.count).toHaveBeenCalledTimes(2);
+    });
+
+    it('should scope both counts to a team when teamId is given', async () => {
+      (prisma.raid.count as any).mockResolvedValue(1);
+
+      await getArchiveStats('guild-123', 'team-alts');
+
+      for (const call of (prisma.raid.count as any).mock.calls) {
+        expect(call[0].where).toEqual(
+          expect.objectContaining({ guildId: 'guild-123', teamId: 'team-alts' })
+        );
+      }
+    });
+
+    it('should stay guild-wide when no teamId is given', async () => {
+      (prisma.raid.count as any).mockResolvedValue(1);
+
+      await getArchiveStats('guild-123');
+
+      for (const call of (prisma.raid.count as any).mock.calls) {
+        expect(call[0].where).not.toHaveProperty('teamId');
+      }
     });
   });
 });

--- a/src/utils/__tests__/attendanceAnalytics.test.ts
+++ b/src/utils/__tests__/attendanceAnalytics.test.ts
@@ -769,3 +769,83 @@ describe('analyzeTrendFromRecords() - additional edge cases', () => {
     expect(trend.confidence).toBeLessThanOrEqual(25);
   });
 });
+
+// --- Optional team filter (multi-team support) ---
+
+describe('optional teamId filter', () => {
+  function lastWhere() {
+    const calls = (mockedPrisma.raidAttendance.findMany as jest.Mock).mock.calls;
+    return calls[calls.length - 1][0].where;
+  }
+
+  beforeEach(() => {
+    (mockedPrisma.raidAttendance.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  describe('getPlayerAttendanceHistory()', () => {
+    it('should scope the query to the team when teamId is given', async () => {
+      await getPlayerAttendanceHistory('user-1', 'guild-1', 'month', 'team-1');
+
+      expect(lastWhere().teamId).toBe('team-1');
+    });
+
+    it('should not add a teamId filter when omitted', async () => {
+      await getPlayerAttendanceHistory('user-1', 'guild-1', 'month');
+
+      expect(lastWhere()).not.toHaveProperty('teamId');
+    });
+  });
+
+  describe('calculatePlayerStats()', () => {
+    it('should scope the query to the team when teamId is given', async () => {
+      await calculatePlayerStats('user-1', 'guild-1', 'month', 'team-1');
+
+      expect(lastWhere().teamId).toBe('team-1');
+    });
+
+    it('should not add a teamId filter when omitted', async () => {
+      await calculatePlayerStats('user-1', 'guild-1', 'month');
+
+      expect(lastWhere()).not.toHaveProperty('teamId');
+    });
+  });
+
+  describe('getPlayerRoleDistribution()', () => {
+    it('should scope the query to the team when teamId is given', async () => {
+      await getPlayerRoleDistribution('user-1', 'guild-1', 'team-1');
+
+      expect(lastWhere().teamId).toBe('team-1');
+    });
+
+    it('should not add a teamId filter when omitted', async () => {
+      await getPlayerRoleDistribution('user-1', 'guild-1');
+
+      expect(lastWhere()).not.toHaveProperty('teamId');
+    });
+  });
+
+  describe('getTrendData()', () => {
+    it('should scope the query to the team when teamId is given', async () => {
+      await getTrendData('user-1', 'guild-1', 30, 'team-1');
+
+      const where = lastWhere();
+      expect(where.teamId).toBe('team-1');
+      // Team scope must not replace the existing guild/date scoping
+      expect(where.guildId).toBe('guild-1');
+      expect(where.raid.raidDate.gte).toBeDefined();
+    });
+
+    it('should not add a teamId filter when omitted', async () => {
+      await getTrendData('user-1', 'guild-1', 30);
+
+      expect(lastWhere()).not.toHaveProperty('teamId');
+    });
+
+    it('should keep the default period when teamId is passed without periodDays', async () => {
+      const trend = await getTrendData('user-1', 'guild-1', undefined, 'team-1');
+      // Default 90 days = 13 weekly buckets
+      expect(trend.dataPoints.length).toBe(13);
+      expect(lastWhere().teamId).toBe('team-1');
+    });
+  });
+});

--- a/src/utils/__tests__/raidScheduler.test.ts
+++ b/src/utils/__tests__/raidScheduler.test.ts
@@ -8,11 +8,15 @@ jest.mock('../archiveManager');
 jest.mock('../../commands/raid', () => ({
   createRaidEmbed: jest.fn(),
 }));
+jest.mock('../teamContext', () => ({
+  getTeamLabel: jest.fn(),
+}));
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import prisma from '../../database/client';
 import { archiveRaid } from '../archiveManager';
 import { createRaidEmbed } from '../../commands/raid';
+import { getTeamLabel } from '../teamContext';
 
 describe('raidScheduler', () => {
   let mockClient: any;
@@ -41,6 +45,9 @@ describe('raidScheduler', () => {
 
     // Setup createRaidEmbed mock
     (createRaidEmbed as jest.Mock<any>).mockResolvedValue({ title: 'Test Raid' });
+
+    // Default: single-team guild -> no team is named anywhere
+    (getTeamLabel as jest.Mock<any>).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -225,6 +232,116 @@ describe('raidScheduler', () => {
 
       // Verify: archiveRaid should NOT be called
       expect(archiveRaid).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkAndCloseExpiredRaids - Team awareness', () => {
+    const raidId = 'raid-team';
+    const guildId = 'guild-team';
+
+    const makeExpiredRaid = (overrides: any = {}): any => ({
+      id: raidId,
+      guildId,
+      teamId: 'team-b',
+      description: 'Test Raid',
+      raidDate: new Date(Date.now() - 1000),
+      status: 'open',
+      messageId: 'message-123',
+      channelId: 'channel-123',
+      guild: {
+        id: guildId,
+        autoArchive: false,
+        archiveChannelId: null,
+        language: 'en',
+      },
+      ...overrides,
+    });
+
+    const mockChannelWithMessage = () => {
+      const mockMessage = { edit: jest.fn().mockResolvedValue(undefined) };
+      mockClient.channels.fetch.mockResolvedValue({
+        isTextBased: () => true,
+        messages: { fetch: jest.fn().mockResolvedValue(mockMessage) },
+      });
+      return mockMessage;
+    };
+
+    const loggedLines = (): string[] =>
+      logSpy.mock.calls.map((call: any[]) => String(call[0]));
+
+    it('scans raids across all teams - the query is not team-scoped', async () => {
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([]);
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      const where = (prisma.raid.findMany as jest.Mock<any>).mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('teamId');
+      expect(where).toEqual({ status: 'open', raidDate: { lt: expect.any(Date) } });
+    });
+
+    it('names the team when closing a raid in a multi-team guild', async () => {
+      (getTeamLabel as jest.Mock<any>).mockResolvedValue('Team B');
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([makeExpiredRaid()]);
+      (prisma.raid.update as jest.Mock<any>).mockResolvedValue(undefined);
+      mockChannelWithMessage();
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(getTeamLabel).toHaveBeenCalledWith(guildId, 'team-b');
+      expect(loggedLines()).toContain(`✅ Auto-closed raid: Test Raid (${raidId}) (Team: Team B)`);
+    });
+
+    it('keeps the wording unchanged for a single-team guild', async () => {
+      // getTeamLabel returns null for single-team guilds (see teamContext)
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([makeExpiredRaid()]);
+      (prisma.raid.update as jest.Mock<any>).mockResolvedValue(undefined);
+      mockChannelWithMessage();
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(loggedLines()).toContain(`✅ Auto-closed raid: Test Raid (${raidId})`);
+    });
+
+    it('names the team on the auto-archive path too', async () => {
+      (getTeamLabel as jest.Mock<any>).mockResolvedValue('Team B');
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([
+        makeExpiredRaid({
+          guild: {
+            id: guildId,
+            autoArchive: true,
+            archiveChannelId: 'archive-123',
+            language: 'en',
+          },
+        }),
+      ]);
+      (prisma.raid.update as jest.Mock<any>).mockResolvedValue(undefined);
+      (archiveRaid as jest.Mock<any>).mockResolvedValue(undefined);
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      const lines = loggedLines();
+      expect(lines).toContain(`✅ Auto-archived raid: Test Raid (${raidId}) (Team: Team B)`);
+      expect(lines).toContain(
+        `✅ Auto-closed and archived raid: Test Raid (${raidId}) (Team: Team B)`
+      );
+    });
+
+    it('stays silent about teams when the raid has no team yet', async () => {
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([
+        makeExpiredRaid({ teamId: null }),
+      ]);
+      (prisma.raid.update as jest.Mock<any>).mockResolvedValue(undefined);
+      mockChannelWithMessage();
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(getTeamLabel).toHaveBeenCalledWith(guildId, null);
+      expect(loggedLines()).toContain(`✅ Auto-closed raid: Test Raid (${raidId})`);
     });
   });
 

--- a/src/utils/__tests__/teamContext.test.ts
+++ b/src/utils/__tests__/teamContext.test.ts
@@ -1,0 +1,150 @@
+jest.mock('../../services/teamService', () => ({
+  getDefaultTeam: jest.fn(),
+  getTeamByName: jest.fn(),
+  listTeams: jest.fn(),
+}));
+
+import { SlashCommandSubcommandBuilder } from 'discord.js';
+import { getDefaultTeam, getTeamByName, listTeams } from '../../services/teamService';
+import {
+  addTeamOption,
+  resolveTeam,
+  teamAutocomplete,
+  TEAM_OPTION_NAME,
+} from '../teamContext';
+
+/** Minimal Team row shaped like the Prisma model. */
+function team(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'team-1',
+    guildId: 'guild1',
+    name: 'Main',
+    isDefault: true,
+    createdBy: 'system',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  } as any;
+}
+
+/** Autocomplete interaction stub with a recorded `respond` call. */
+function autocompleteInteraction(guildId: string | null, focused: string) {
+  return {
+    guildId,
+    options: { getFocused: () => focused },
+    respond: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('resolveTeam', () => {
+  it('falls back to the default team when no option was supplied', async () => {
+    (getDefaultTeam as jest.Mock).mockResolvedValue(team());
+
+    const result = await resolveTeam('guild1', null);
+
+    expect(result.error).toBeUndefined();
+    expect(result.team?.id).toBe('team-1');
+    expect(getDefaultTeam).toHaveBeenCalledWith('guild1');
+    expect(getTeamByName).not.toHaveBeenCalled();
+  });
+
+  it('treats a blank/whitespace option like a missing one', async () => {
+    (getDefaultTeam as jest.Mock).mockResolvedValue(team());
+
+    const result = await resolveTeam('guild1', '   ');
+
+    expect(result.team?.id).toBe('team-1');
+    expect(getTeamByName).not.toHaveBeenCalled();
+  });
+
+  it('resolves a named team, trimming the input', async () => {
+    (getTeamByName as jest.Mock).mockResolvedValue(team({ id: 'team-2', name: 'Alts', isDefault: false }));
+
+    const result = await resolveTeam('guild1', '  Alts  ');
+
+    expect(getTeamByName).toHaveBeenCalledWith('guild1', 'Alts');
+    expect(result.team?.name).toBe('Alts');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('reports an unknown team as not_found instead of throwing', async () => {
+    (getTeamByName as jest.Mock).mockResolvedValue(null);
+
+    const result = await resolveTeam('guild1', 'Ghosts');
+
+    expect(result).toEqual({ team: null, error: 'not_found' });
+    expect(getDefaultTeam).not.toHaveBeenCalled();
+  });
+});
+
+describe('addTeamOption', () => {
+  it('attaches an optional autocompleting string option named "team"', () => {
+    const subcommand = addTeamOption(
+      new SlashCommandSubcommandBuilder().setName('create').setDescription('Create a raid')
+    );
+
+    const json = subcommand.toJSON();
+    const option = json.options?.find((o: any) => o.name === TEAM_OPTION_NAME) as any;
+
+    expect(option).toBeDefined();
+    expect(option.required).toBeFalsy();
+    expect(option.autocomplete).toBe(true);
+    expect(option.description).toBe('Team (defaults to your main team)');
+  });
+});
+
+describe('teamAutocomplete', () => {
+  it('returns the guild teams filtered by the typed prefix', async () => {
+    (listTeams as jest.Mock).mockResolvedValue([
+      team({ id: 't1', name: 'Main' }),
+      team({ id: 't2', name: 'Mythic Core', isDefault: false }),
+      team({ id: 't3', name: 'Alts', isDefault: false }),
+    ]);
+
+    const interaction = autocompleteInteraction('guild1', 'my');
+    await teamAutocomplete(interaction);
+
+    expect(listTeams).toHaveBeenCalledWith('guild1');
+    expect(interaction.respond).toHaveBeenCalledWith([
+      { name: 'Mythic Core', value: 'Mythic Core' },
+    ]);
+  });
+
+  it('returns every team when nothing has been typed yet', async () => {
+    (listTeams as jest.Mock).mockResolvedValue([
+      team({ id: 't1', name: 'Main' }),
+      team({ id: 't2', name: 'Alts', isDefault: false }),
+    ]);
+
+    const interaction = autocompleteInteraction('guild1', '');
+    await teamAutocomplete(interaction);
+
+    expect(interaction.respond).toHaveBeenCalledWith([
+      { name: 'Main', value: 'Main' },
+      { name: 'Alts', value: 'Alts' },
+    ]);
+  });
+
+  it('caps the response at Discord\'s 25-choice limit', async () => {
+    (listTeams as jest.Mock).mockResolvedValue(
+      Array.from({ length: 40 }, (_, i) => team({ id: `t${i}`, name: `Team ${i}`, isDefault: false }))
+    );
+
+    const interaction = autocompleteInteraction('guild1', 'team');
+    await teamAutocomplete(interaction);
+
+    expect(interaction.respond.mock.calls[0][0]).toHaveLength(25);
+  });
+
+  it('responds empty outside a guild rather than throwing', async () => {
+    const interaction = autocompleteInteraction(null, 'main');
+    await teamAutocomplete(interaction);
+
+    expect(interaction.respond).toHaveBeenCalledWith([]);
+    expect(listTeams).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/teamContext.test.ts
+++ b/src/utils/__tests__/teamContext.test.ts
@@ -1,13 +1,22 @@
 jest.mock('../../services/teamService', () => ({
+  countTeams: jest.fn(),
   getDefaultTeam: jest.fn(),
+  getTeamById: jest.fn(),
   getTeamByName: jest.fn(),
   listTeams: jest.fn(),
 }));
 
 import { SlashCommandSubcommandBuilder } from 'discord.js';
-import { getDefaultTeam, getTeamByName, listTeams } from '../../services/teamService';
+import {
+  countTeams,
+  getDefaultTeam,
+  getTeamById,
+  getTeamByName,
+  listTeams,
+} from '../../services/teamService';
 import {
   addTeamOption,
+  getTeamLabel,
   resolveTeam,
   teamAutocomplete,
   TEAM_OPTION_NAME,
@@ -146,5 +155,33 @@ describe('teamAutocomplete', () => {
 
     expect(interaction.respond).toHaveBeenCalledWith([]);
     expect(listTeams).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTeamLabel()', () => {
+  it('returns null for single-team guilds without looking the team up', async () => {
+    (countTeams as jest.Mock).mockResolvedValue(1);
+
+    await expect(getTeamLabel('guild1', 'team-1')).resolves.toBeNull();
+    expect(getTeamById).not.toHaveBeenCalled();
+  });
+
+  it('returns the team name once the guild has more than one team', async () => {
+    (countTeams as jest.Mock).mockResolvedValue(2);
+    (getTeamById as jest.Mock).mockResolvedValue(team({ id: 'team-2', name: 'Alts', isDefault: false }));
+
+    await expect(getTeamLabel('guild1', 'team-2')).resolves.toBe('Alts');
+  });
+
+  it('returns null for a missing teamId without querying', async () => {
+    await expect(getTeamLabel('guild1', null)).resolves.toBeNull();
+    expect(countTeams).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the team row is gone', async () => {
+    (countTeams as jest.Mock).mockResolvedValue(3);
+    (getTeamById as jest.Mock).mockResolvedValue(null);
+
+    await expect(getTeamLabel('guild1', 'team-deleted')).resolves.toBeNull();
   });
 });

--- a/src/utils/archiveManager.ts
+++ b/src/utils/archiveManager.ts
@@ -12,6 +12,7 @@ export interface ArchiveSearchFilter {
   startDate?: Date;
   endDate?: Date;
   guildId: string;
+  teamId?: string; // Optional: restrict results to a single team of the guild
 }
 
 /**
@@ -291,7 +292,7 @@ export async function searchArchive(
   filters: ArchiveSearchFilter,
   pageSize: number = 25,
 ): Promise<ArchiveRaidSummary[]> {
-  const { guildId, query, startDate, endDate } = filters;
+  const { guildId, query, startDate, endDate, teamId } = filters;
 
   // Build where clause dynamically based on search parameters
   const where: any = {
@@ -300,6 +301,11 @@ export async function searchArchive(
       not: null,
     },
   };
+
+  // Optional team scope — omitted filters keep the previous guild-wide behaviour
+  if (teamId) {
+    where.teamId = teamId;
+  }
 
   // Add date range filter if provided
   if (startDate || endDate) {
@@ -378,12 +384,18 @@ export async function searchArchive(
 /**
  * Get archive stats for a guild (total archived, recent archives).
  * Uses database-level aggregation to avoid loading all raids into memory.
+ *
+ * @param guildId - The guild context
+ * @param teamId - Optional team scope; omitted counts stay guild-wide (all teams)
  */
-export async function getArchiveStats(guildId: string) {
+export async function getArchiveStats(guildId: string, teamId?: string) {
+   const teamScope = teamId ? { teamId } : {};
+
    // Get total count of archived raids
    const totalArchived = await prisma.raid.count({
      where: {
        guildId,
+       ...teamScope,
        archivedAt: { not: null }
      }
    });
@@ -391,11 +403,12 @@ export async function getArchiveStats(guildId: string) {
    // Get count of recently archived raids (last 30 days)
    const thirtyDaysAgo = new Date();
    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-   
+
    const recentArchived = await prisma.raid.count({
      where: {
        guildId,
-       archivedAt: { 
+       ...teamScope,
+       archivedAt: {
          not: null,
          gte: thirtyDaysAgo
        }

--- a/src/utils/attendanceAnalytics.ts
+++ b/src/utils/attendanceAnalytics.ts
@@ -306,12 +306,14 @@ export async function getPlayerRoleDistribution(
  * @param userId - Discord user ID
  * @param guildId - Guild ID
  * @param periodDays - Number of days to analyze (default 90)
+ * @param teamId - Optional team scope; omitted means guild-wide (pre-multi-team behaviour)
  * @returns TrendAnalysis with weekly data points and direction
  */
 export async function getTrendData(
   userId: string,
   guildId: string,
   periodDays: number = 90,
+  teamId?: string,
 ): Promise<TrendAnalysis> {
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - periodDays);
@@ -320,6 +322,7 @@ export async function getTrendData(
     where: {
       userId,
       guildId,
+      ...(teamId ? { teamId } : {}),
       raid: { raidDate: { gte: cutoff } },
     },
     include: {

--- a/src/utils/attendanceAnalytics.ts
+++ b/src/utils/attendanceAnalytics.ts
@@ -100,12 +100,14 @@ function getDateCutoff(days?: number): Date | undefined {
  * @param userId - Discord user ID
  * @param guildId - Guild ID
  * @param period - Time period: 'month' (30d), 'quarter' (90d), 'all'
+ * @param teamId - Optional team scope; omitted means guild-wide (pre-multi-team behaviour)
  * @returns Array of attendance history entries sorted by date descending
  */
 export async function getPlayerAttendanceHistory(
   userId: string,
   guildId: string,
   period?: string,
+  teamId?: string,
 ): Promise<AttendanceHistoryEntry[]> {
   const days = periodToDays(period);
   const cutoff = getDateCutoff(days);
@@ -114,6 +116,7 @@ export async function getPlayerAttendanceHistory(
     where: {
       userId,
       guildId,
+      ...(teamId ? { teamId } : {}),
       ...(cutoff ? { raid: { raidDate: { gte: cutoff } } } : {}),
     },
     include: {
@@ -149,12 +152,14 @@ export async function getPlayerAttendanceHistory(
  * @param userId - Discord user ID
  * @param guildId - Guild ID
  * @param period - Time period: 'month' (30d), 'quarter' (90d), 'all'
+ * @param teamId - Optional team scope; omitted means guild-wide (pre-multi-team behaviour)
  * @returns PlayerStats with attendance breakdown, reliability, response time, and trend
  */
 export async function calculatePlayerStats(
   userId: string,
   guildId: string,
   period?: string,
+  teamId?: string,
 ): Promise<PlayerStats> {
   const days = periodToDays(period);
   const cutoff = getDateCutoff(days);
@@ -163,6 +168,7 @@ export async function calculatePlayerStats(
     where: {
       userId,
       guildId,
+      ...(teamId ? { teamId } : {}),
       ...(cutoff ? { raid: { raidDate: { gte: cutoff } } } : {}),
     },
     include: {
@@ -224,16 +230,19 @@ export async function calculatePlayerStats(
  *
  * @param userId - Discord user ID
  * @param guildId - Guild ID
+ * @param teamId - Optional team scope; omitted means guild-wide (pre-multi-team behaviour)
  * @returns PlayerRoleDistribution with main role, alt roles, and flexibility score
  */
 export async function getPlayerRoleDistribution(
   userId: string,
   guildId: string,
+  teamId?: string,
 ): Promise<PlayerRoleDistribution> {
   const records = await prisma.raidAttendance.findMany({
     where: {
       userId,
       guildId,
+      ...(teamId ? { teamId } : {}),
       status: { in: ['attending', 'late'] },
     },
     select: {

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -216,7 +216,6 @@ export interface Translations {
     premiumWeeklyLimitInfo: string;
     premiumTierFree: string;
     premiumTierPremium: string;
-    premiumTierPro: string;
     premiumExpired: string;
     premiumAttendanceCapped: string;
 
@@ -470,7 +469,6 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumWeeklyLimitInfo: 'You have {remaining} raids left this week.',
         premiumTierFree: 'Free',
         premiumTierPremium: 'Premium',
-        premiumTierPro: 'Pro',
         premiumExpired: 'Your {tier} subscription has expired.',
         premiumAttendanceCapped: 'Showing last {count} raids. Upgrade to Premium for full history.',
 
@@ -712,7 +710,6 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumWeeklyLimitInfo: 'Du hast noch {remaining} Raids diese Woche übrig.',
         premiumTierFree: 'Free',
         premiumTierPremium: 'Premium',
-        premiumTierPro: 'Pro',
         premiumExpired: 'Dein {tier}-Abonnement ist abgelaufen.',
         premiumAttendanceCapped: 'Zeige die letzten {count} Raids. Upgrade auf Premium für die vollständige Historie.',
 

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -239,6 +239,20 @@ export interface Translations {
     featureStatsFullHistory: string;
     featureStatsAnalytics: string;
     featureStatsExport: string;
+    featureTeamMulti: string;
+
+    // Teams (Phase 3 — multi-team support)
+    teamCreated: string;
+    teamDeleted: string;
+    teamAlreadyExists: string;
+    teamNotFound: string;
+    teamCannotDeleteDefault: string;
+    teamListTitle: string;
+    teamListEmpty: string;
+    teamListEntry: string;
+    teamDefaultBadge: string;
+    teamInvalidName: string;
+    teamLimitReached: string;
 }
 
 /**
@@ -492,6 +506,20 @@ const translations: Record<SupportedLanguage, Translations> = {
         featureStatsFullHistory: 'Full Attendance History',
         featureStatsAnalytics: 'Attendance Analytics',
         featureStatsExport: 'Statistics Export',
+        featureTeamMulti: 'Multiple Teams',
+
+        // Teams (Phase 3 — multi-team support)
+        teamCreated: '✅ Team **{name}** created.',
+        teamDeleted: '🗑️ Team **{name}** deleted.',
+        teamAlreadyExists: '⚠️ A team named **{name}** already exists.',
+        teamNotFound: '❌ No team named **{name}** found.',
+        teamCannotDeleteDefault: '❌ The default team cannot be deleted.',
+        teamListTitle: '👥 Teams',
+        teamListEmpty: 'No teams yet.',
+        teamListEntry: '• **{name}** — {count} raids',
+        teamDefaultBadge: 'default',
+        teamInvalidName: '❌ Please provide a valid team name (1-50 characters).',
+        teamLimitReached: 'You\'ve reached the free limit of {max} team. Upgrade to Premium for unlimited teams.',
     },
 
   de: {
@@ -733,6 +761,20 @@ const translations: Record<SupportedLanguage, Translations> = {
         featureStatsFullHistory: 'Vollständige Anwesenheitshistorie',
         featureStatsAnalytics: 'Anwesenheitsanalysen',
         featureStatsExport: 'Statistik-Export',
+        featureTeamMulti: 'Mehrere Teams',
+
+        // Teams (Phase 3 — multi-team support)
+        teamCreated: '✅ Team **{name}** erstellt.',
+        teamDeleted: '🗑️ Team **{name}** gelöscht.',
+        teamAlreadyExists: '⚠️ Ein Team mit dem Namen **{name}** existiert bereits.',
+        teamNotFound: '❌ Kein Team mit dem Namen **{name}** gefunden.',
+        teamCannotDeleteDefault: '❌ Das Standard-Team kann nicht gelöscht werden.',
+        teamListTitle: '👥 Teams',
+        teamListEmpty: 'Noch keine Teams vorhanden.',
+        teamListEntry: '• **{name}** — {count} Raids',
+        teamDefaultBadge: 'Standard',
+        teamInvalidName: '❌ Bitte gib einen gültigen Team-Namen an (1-50 Zeichen).',
+        teamLimitReached: 'Du hast das kostenlose Limit von {max} Team erreicht. Upgrade auf Premium für unbegrenzt viele Teams.',
     },
 };
 

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -225,10 +225,12 @@ export interface Translations {
     premiumUpsellCurrentPlan: string;
     premiumUpsellRequiredPlan: string;
     premiumUpsellHowTo: string;
+    premiumUpsellPerks: string;
     premiumFooterHint: string;
 
     // Premium trial (Phase 1.6)
     premiumTrialGranted: string;
+    premiumTrialTeamsHint: string;
 
     // Premium feature display names (localized upsell embed)
     featureRaidOptoutReason: string;
@@ -492,10 +494,12 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumUpsellCurrentPlan: 'Your Plan',
         premiumUpsellRequiredPlan: 'Required Plan',
         premiumUpsellHowTo: 'Tap the bot\'s profile → **Store**, or open **Server Settings → Subscriptions** to upgrade.',
-        premiumFooterHint: '-# 💎 Upgrade to Premium to unlock archives, analytics & unlimited raids.',
+        premiumUpsellPerks: '• **Multiple teams** — run mains, alts and second groups side by side\n• Unlimited raids per week\n• Raid archives & full history\n• Attendance analytics & trends',
+        premiumFooterHint: '-# 💎 Upgrade to Premium for multiple teams, archives, analytics & unlimited raids.',
 
         // Premium trial (Phase 1.6)
         premiumTrialGranted: '🎁 **Your 14-day {tier} trial is active!** Enjoy unlimited raids, archives and analytics — no card required. It ends automatically, nothing to cancel.',
+        premiumTrialTeamsHint: 'During your trial you can create as many teams as you like.',
 
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Opt-Out Reasons',
@@ -747,10 +751,12 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumUpsellCurrentPlan: 'Dein Plan',
         premiumUpsellRequiredPlan: 'Benötigter Plan',
         premiumUpsellHowTo: 'Tippe auf das Bot-Profil → **Shop**, oder öffne **Servereinstellungen → Abonnements**, um zu upgraden.',
-        premiumFooterHint: '-# 💎 Upgrade auf Premium für Archive, Analysen & unbegrenzte Raids.',
+        premiumUpsellPerks: '• **Mehrere Teams** – Mains, Twinks und Zweitgruppen parallel führen\n• Unbegrenzte Raids pro Woche\n• Raid-Archive & vollständige Historie\n• Anwesenheits-Analysen & Trends',
+        premiumFooterHint: '-# 💎 Upgrade auf Premium für mehrere Teams, Archive, Analysen & unbegrenzte Raids.',
 
         // Premium trial (Phase 1.6)
         premiumTrialGranted: '🎁 **Deine 14-tägige {tier}-Testphase ist aktiv!** Genieße unbegrenzte Raids, Archive und Analysen – ohne Kreditkarte. Sie endet automatisch, nichts zu kündigen.',
+        premiumTrialTeamsHint: 'Während der Testphase kannst du beliebig viele Teams anlegen.',
 
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Abmeldungsgründe',

--- a/src/utils/raidScheduler.ts
+++ b/src/utils/raidScheduler.ts
@@ -2,6 +2,18 @@ import { Client } from 'discord.js';
 import prisma, { withRetry } from '../database/client';
 import { createRaidEmbed } from '../commands/raid';
 import { archiveRaid } from './archiveManager';
+import { getTeamLabel } from './teamContext';
+
+/**
+ * Formats a raid's team for the scheduler's log output.
+ *
+ * `getTeamLabel` already returns `null` for single-team guilds, so their log lines stay
+ * byte-for-byte identical to the pre-multi-team wording. Plain text, no markdown — these
+ * end up in the operator console, not in a Discord message.
+ */
+function teamSuffix(label: string | null): string {
+  return label ? ` (Team: ${label})` : '';
+}
 
 /**
  * Starts a background scheduler that automatically closes expired raids.
@@ -38,7 +50,10 @@ export function startRaidScheduler(client: Client) {
 export async function checkAndCloseExpiredRaids(client: Client) {
   const now = new Date();
 
-  // Find all open raids that have expired
+  // Find all open raids that have expired.
+  // Deliberately NOT scoped by team: auto-close and auto-archive are background maintenance
+  // and must cover every team of every guild. Adding a `teamId` filter here would silently
+  // leave the raids of all non-default teams open forever.
   const expiredRaids = await withRetry(() =>
     prisma.raid.findMany({
       where: {
@@ -67,6 +82,10 @@ export async function checkAndCloseExpiredRaids(client: Client) {
          }),
        );
 
+       // Name the team in the log lines below, but only when the guild actually has more
+       // than one — resolved once per raid so a multi-team guild pays a single lookup.
+       const teamLabel = teamSuffix(await getTeamLabel(raid.guildId, raid.teamId));
+
          // Check if auto-archive is enabled for this guild
          const shouldAutoArchive = !!(raid.guild.autoArchive && raid.guild.archiveChannelId);
          let archivedSuccessfully = false;
@@ -76,7 +95,7 @@ export async function checkAndCloseExpiredRaids(client: Client) {
           try {
             await archiveRaid(raid.id, raid.guildId, client);
             archivedSuccessfully = true;
-            console.log(`✅ Auto-archived raid: ${raid.description} (${raid.id})`);
+            console.log(`✅ Auto-archived raid: ${raid.description} (${raid.id})${teamLabel}`);
           } catch (archiveError) {
             console.error(`⚠️ Failed to auto-archive raid ${raid.id}:`, archiveError);
             // Continue with regular closure even if archiving fails
@@ -97,16 +116,16 @@ export async function checkAndCloseExpiredRaids(client: Client) {
                components: [],
              });
 
-              console.log(`✅ Auto-closed raid: ${raid.description} (${raid.id})`);
+              console.log(`✅ Auto-closed raid: ${raid.description} (${raid.id})${teamLabel}`);
             }
           } catch (error) {
             console.error(`Error updating message for raid ${raid.id}:`, error);
           }
         } else if (archivedSuccessfully) {
-          console.log(`✅ Auto-closed and archived raid: ${raid.description} (${raid.id})`);
+          console.log(`✅ Auto-closed and archived raid: ${raid.description} (${raid.id})${teamLabel}`);
         } else if (raid.messageId && raid.channelId) {
           // This case handles when shouldAutoArchive was false but we didn't have message to update
-          console.log(`✅ Auto-closed raid (no message update needed): ${raid.description} (${raid.id})`);
+          console.log(`✅ Auto-closed raid (no message update needed): ${raid.description} (${raid.id})${teamLabel}`);
         }
      } catch (error) {
        console.error(`Error closing raid ${raid.id}:`, error);

--- a/src/utils/teamContext.ts
+++ b/src/utils/teamContext.ts
@@ -2,7 +2,14 @@ import {
   AutocompleteInteraction,
   SlashCommandSubcommandBuilder,
 } from 'discord.js';
-import { getDefaultTeam, getTeamByName, listTeams, type Team } from '../services/teamService';
+import {
+  countTeams,
+  getDefaultTeam,
+  getTeamById,
+  getTeamByName,
+  listTeams,
+  type Team,
+} from '../services/teamService';
 
 /** Discord hard limit on autocomplete choices per response. */
 const MAX_AUTOCOMPLETE_CHOICES = 25;
@@ -42,6 +49,24 @@ export async function resolveTeam(
   if (!team) return { team: null, error: 'not_found' };
 
   return { team };
+}
+
+/**
+ * Name of a raid's team, but only when it is worth showing.
+ *
+ * Returns `null` for single-team guilds so their command output stays byte-for-byte
+ * identical to the pre-multi-team wording, and also when the raid carries no (or a
+ * dangling) `teamId`. Callers treat `null` as "say nothing about teams".
+ */
+export async function getTeamLabel(
+  guildId: string,
+  teamId: string | null | undefined
+): Promise<string | null> {
+  if (!teamId) return null;
+  if ((await countTeams(guildId)) <= 1) return null;
+
+  const team = await getTeamById(teamId);
+  return team?.name ?? null;
 }
 
 /**

--- a/src/utils/teamContext.ts
+++ b/src/utils/teamContext.ts
@@ -1,0 +1,86 @@
+import {
+  AutocompleteInteraction,
+  SlashCommandSubcommandBuilder,
+} from 'discord.js';
+import { getDefaultTeam, getTeamByName, listTeams, type Team } from '../services/teamService';
+
+/** Discord hard limit on autocomplete choices per response. */
+const MAX_AUTOCOMPLETE_CHOICES = 25;
+
+/** Name of the shared, optional `team` option every team-aware subcommand carries. */
+export const TEAM_OPTION_NAME = 'team';
+
+/**
+ * Result of {@link resolveTeam}.
+ *
+ * Either a team was resolved, or the explicitly named team does not exist in that guild.
+ * Modelled as a union so callers cannot read `team` on the failure path.
+ */
+export type TeamResolution =
+  | { team: Team; error?: undefined }
+  | { team: null; error: 'not_found' };
+
+/**
+ * Resolves the team a command should operate on.
+ *
+ * Backwards compatibility: when no `team` option was supplied the guild's default team is
+ * used, so single-team (and all FREE) guilds keep their previous behaviour. A named team
+ * that does not exist is reported as a failure rather than thrown, because the command
+ * layer answers it with an ephemeral `teamNotFound` message.
+ */
+export async function resolveTeam(
+  guildId: string,
+  teamNameOption: string | null
+): Promise<TeamResolution> {
+  const name = teamNameOption?.trim();
+
+  if (!name) {
+    return { team: await getDefaultTeam(guildId) };
+  }
+
+  const team = await getTeamByName(guildId, name);
+  if (!team) return { team: null, error: 'not_found' };
+
+  return { team };
+}
+
+/**
+ * Attaches the shared optional `team` option to a subcommand builder.
+ *
+ * Centralised so every team-aware subcommand across `raid`, `stats` and friends exposes an
+ * identical option definition (name, description, autocomplete).
+ */
+export function addTeamOption(
+  subcommand: SlashCommandSubcommandBuilder
+): SlashCommandSubcommandBuilder {
+  return subcommand.addStringOption((option) =>
+    option
+      .setName(TEAM_OPTION_NAME)
+      .setDescription('Team (defaults to your main team)')
+      .setRequired(false)
+      .setAutocomplete(true)
+  );
+}
+
+/**
+ * Answers a `team` option autocomplete with the guild's teams, prefix-filtered.
+ *
+ * Silently does nothing outside a guild — Discord accepts an unanswered autocomplete far
+ * better than a thrown handler.
+ */
+export async function teamAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const focused = interaction.options.getFocused().toLowerCase();
+  const teams = await listTeams(interaction.guildId);
+
+  const choices = teams
+    .filter((team) => team.name.toLowerCase().startsWith(focused))
+    .slice(0, MAX_AUTOCOMPLETE_CHOICES)
+    .map((team) => ({ name: team.name, value: team.name }));
+
+  await interaction.respond(choices);
+}

--- a/src/utils/welcomeEmbed.ts
+++ b/src/utils/welcomeEmbed.ts
@@ -74,7 +74,8 @@ export function buildWelcomeEmbed(params: WelcomeEmbedParams): EmbedBuilder {
         name: '📋 Useful Commands',
         value: '• `/config view` - View current settings\n' +
                '• `/raid list` - List upcoming raids\n' +
-               '• `/raid delete` - Delete a raid',
+               '• `/raid delete` - Delete a raid\n' +
+               '• `/team list` - Run several raid teams side by side (mains, alts, second group)',
         inline: false,
       }
     )
@@ -86,7 +87,8 @@ export function buildWelcomeEmbed(params: WelcomeEmbedParams): EmbedBuilder {
   if (trialGranted) {
     welcomeEmbed.addFields({
       name: `🎁 ${TRIAL_DAYS}-Day Premium Trial`,
-      value: t(language, 'premiumTrialGranted', { tier: t(language, 'premiumTierPremium') }),
+      value: t(language, 'premiumTrialGranted', { tier: t(language, 'premiumTierPremium') }) +
+             `\n${t(language, 'premiumTrialTeamsHint')}`,
       inline: false,
     });
   }


### PR DESCRIPTION
## Was & Warum

Das Tier-Modell wird von drei auf **zwei Stufen** reduziert: `FREE` und `PREMIUM`. Die Stufe `PRO` entfiel praktisch als eigenständiges Produkt und hat nur Verzweigungen im Code, in den Texten und in den Gates verdoppelt.

Gleichzeitig kommt **Multi-Team-Support** als konkreter Kaufgrund für Premium dazu:

- **FREE** — genau **1 Team** pro Guild (das automatisch angelegte Default-Team `Main`).
- **PREMIUM** — **mehrere Teams** pro Guild, jeweils mit eigenen Raids, Anwesenheiten und Statistiken.

Damit hat Premium erstmals ein Feature, das strukturell (nicht nur kosmetisch) mehr kann, und die Upsell-Hinweise in den Command-Footern haben ein echtes Ziel.

## Migrationen

Zwei Migrationsschritte, Reihenfolge ist wichtig:

1. **Enum-Verkleinerung** `FREE | PREMIUM | PRO` → `FREE | PREMIUM`
   - Zuerst **Daten**: alle Guilds mit `tier = 'PRO'` werden auf `PREMIUM` hochgezogen (kein Downgrade, niemand verliert Funktionen).
   - Danach **Typ-Swap**: der Enum-Wert `PRO` wird entfernt.
2. **Team-Datenmodell + Backfill**
   - Neue `Team`-Tabelle, `teamId` zunächst **nullable** an den abhängigen Datensätzen.
   - Backfill: für **jede** Guild wird ein Default-Team `Main` angelegt, alle bestehenden Raids/Anwesenheiten werden diesem Team zugeordnet.
   - Erst danach wird `teamId` auf **NOT NULL** gesetzt.

## Rückwärtskompatibilität

- Die `team`-Option ist in **allen** Commands **optional**. Ohne Angabe wird das Default-Team der Guild verwendet.
- FREE-Guilds sehen exakt das **alte Verhalten** — ein Team, keine zusätzliche Auswahl, keine geänderten Ausgaben.
- Das **Weekly-Limit bleibt guild-weit** und wird nicht pro Team gezählt. Mehrere Teams sind damit **kein Bypass** für das Raid-Kontingent.

## Tests

- Test-Suite: **695 → 869 grün**.
- `tsc`: **0 Fehler**.
- Neue Suites: `teamGating`, `teamService`, `teamContext`, `attendance-team`, plus cross-command Team-Scoping-Tests und ein Multi-Team-Lifecycle-Integrationstest.

## Umfang

**60 Dateien**, **+4646 / −212**, 38 Commits.

## Reviewer-Fokus

1. **Enum-Migration-Reihenfolge** — Daten-Update vor dem Typ-Swap.
2. **Backfill-Idempotenz** — mehrfaches Ausführen darf keine doppelten Default-Teams erzeugen.
3. **Team-Gating-Enforcement** — greift das FREE-Limit von 1 Team auf allen Pfaden der Team-Neuanlage?
4. **Downgrade-Pfad** — nach Premium-Ablauf müssen bestehende Teams lesbar bleiben, die Neuanlage weiterer Teams aber blockiert sein.

---

## Review-Checkliste für Codex

- [ ] **Enum-Migration-Reihenfolge:** Werden alle `PRO`-Guilds auf `PREMIUM` migriert, **bevor** der Enum-Wert `PRO` entfernt wird? Gibt es einen Zustand, in dem eine Zeile auf einen nicht mehr existierenden Enum-Wert zeigt?
- [ ] **Backfill-Idempotenz:** Erzeugt ein erneuter Lauf des Team-Backfills ein zweites Default-Team `Main` oder verwaiste `teamId`-Referenzen? Ist der `NOT NULL`-Schritt sicher, wenn zwischen Backfill und Constraint neue Zeilen entstehen?
- [ ] **Team-Gating-Enforcement:** Ist das FREE-Limit (1 Team) an **jeder** Stelle der Team-Erstellung durchgesetzt — nicht nur im `/team create`-Command, sondern auch im Service-Layer? Gibt es eine Race Condition bei parallelen Erstellungen?
- [ ] **Downgrade-Pfad:** Nach Premium-Ablauf mit bereits > 1 Team — bleiben alle Teams les- und nutzbar (Raids, Attendance, Stats), während nur die Neuanlage geblockt wird? Kein Datenverlust, keine hart fehlschlagenden Reads.
