### PR TITLE
fix(startup): gate trial backfill on a clean entitlement sync

### DIFF
--- a/src/__tests__/backfillTrials.test.ts
+++ b/src/__tests__/backfillTrials.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../database/client');
 
 import prisma from '../database/client';
-import { backfillTrials } from '../scripts/backfillTrials';
+import { backfillTrials, runStartupTrialBackfill } from '../scripts/backfillTrials';
 import { clearTierCache } from '../services/entitlementService';
 
 const guildMock = (prisma as any).guild;
@@ -152,5 +152,53 @@ describe('backfillTrials', () => {
     expect(result).toEqual({ scanned: 2, granted: 0, skipped: 0 });
     expect(guildMock.updateMany).not.toHaveBeenCalled();
     expect(guildMock.update).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression guard for the Codex MAJOR finding: syncEntitlementsOnStartup() catches its
+ * own errors and used to return void, so the startup backfill ran even after a failed
+ * sync. A paying guild whose entitlementId had not been written would then be picked up
+ * as a FREE candidate and handed a trial instead of its paid tier.
+ */
+describe('runStartupTrialBackfill()', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('does not touch the database when the entitlement sync failed', async () => {
+    const result = await runStartupTrialBackfill({ ok: false });
+
+    expect(result).toBeNull();
+    expect(guildMock.findMany).not.toHaveBeenCalled();
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('logs why the backfill was skipped', async () => {
+    await runStartupTrialBackfill({ ok: false });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Trial backfill skipped'),
+    );
+  });
+
+  it('runs the backfill when the entitlement sync completed cleanly', async () => {
+    guildMock.findMany.mockResolvedValue([{ id: 'g1', name: 'Alpha' }]);
+    guildMock.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await runStartupTrialBackfill({ ok: true });
+
+    expect(result).toEqual({ scanned: 1, granted: 1, skipped: 0 });
+    expect(guildMock.findMany).toHaveBeenCalled();
+  });
+
+  it('swallows a backfill failure so startup is never blocked', async () => {
+    guildMock.findMany.mockRejectedValue(new Error('db down'));
+
+    await expect(runStartupTrialBackfill({ ok: true })).resolves.toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Trial backfill failed'),
+      expect.any(Error),
+    );
   });
 });

--- a/src/__tests__/entitlementService.test.ts
+++ b/src/__tests__/entitlementService.test.ts
@@ -8,6 +8,7 @@ import {
   FEATURE_TIERS,
   tryConsumeWeeklyRaid,
   grantTrialIfEligible,
+  syncEntitlementsOnStartup,
   TRIAL_DAYS,
   clearTierCache,
   PremiumTier,
@@ -285,5 +286,87 @@ describe('grantTrialIfEligible()', () => {
     const result = await grantTrialIfEligible('unknown');
     expect(result.granted).toBe(false);
     expect(result.tier).toBe('FREE');
+  });
+});
+
+describe('syncEntitlementsOnStartup()', () => {
+  const OLD_SKU = process.env.DISCORD_SKU_PREMIUM;
+
+  const clientWith = (overrides: {
+    appId?: string | undefined;
+    get?: jest.Mock;
+  }) => ({
+    application: overrides.appId === undefined ? null : { id: overrides.appId },
+    rest: { get: overrides.get ?? jest.fn().mockResolvedValue([]) },
+  }) as any;
+
+  beforeEach(() => {
+    process.env.DISCORD_SKU_PREMIUM = 'sku-premium';
+    (prisma.guild.update as jest.Mock).mockResolvedValue({} as any);
+  });
+
+  afterAll(() => {
+    process.env.DISCORD_SKU_PREMIUM = OLD_SKU;
+  });
+
+  it('reports ok when every entitlement synced', async () => {
+    const get = jest.fn().mockResolvedValue([
+      { id: 'ent1', sku_id: 'sku-premium', guild_id: 'g1', ends_at: '2099-01-01T00:00:00Z' },
+    ]);
+
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: 'app1', get }));
+
+    expect(result).toEqual({ ok: true });
+    expect(prisma.guild.update).toHaveBeenCalled();
+  });
+
+  it('reports ok when there is nothing to sync', async () => {
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: 'app1' }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('reports ok when entitlements are skipped for an unknown SKU', async () => {
+    const get = jest.fn().mockResolvedValue([
+      { id: 'ent1', sku_id: 'some-other-sku', guild_id: 'g1' },
+    ]);
+
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: 'app1', get }));
+
+    expect(result).toEqual({ ok: true });
+    expect(prisma.guild.update).not.toHaveBeenCalled();
+  });
+
+  it('reports not-ok when the application ID is unavailable', async () => {
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: undefined }));
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('reports not-ok when the Discord REST call fails', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('503 Service Unavailable'));
+
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: 'app1', get }));
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('reports not-ok when a DB write fails mid-sync', async () => {
+    // The paid entitlement never lands in the DB — exactly the state the trial backfill
+    // must not act on, since the guild still looks FREE with a NULL entitlementId.
+    const get = jest.fn().mockResolvedValue([
+      { id: 'ent1', sku_id: 'sku-premium', guild_id: 'g1' },
+      { id: 'ent2', sku_id: 'sku-premium', guild_id: 'g2' },
+    ]);
+    (prisma.guild.update as jest.Mock).mockRejectedValueOnce(new Error('connection lost'));
+
+    const result = await syncEntitlementsOnStartup(clientWith({ appId: 'app1', get }));
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('does not throw on failure — startup must continue', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('boom'));
+    await expect(
+      syncEntitlementsOnStartup(clientWith({ appId: 'app1', get })),
+    ).resolves.toEqual({ ok: false });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { localeToLanguage } from './utils/localization';
 import { buildWelcomeEmbed } from './utils/welcomeEmbed';
 import { getDefaultTeam } from './services/teamService';
 import { TEAM_OPTION_NAME } from './utils/teamContext';
-import { backfillTrials } from './scripts/backfillTrials';
+import { runStartupTrialBackfill } from './scripts/backfillTrials';
 
 config();
 
@@ -109,7 +109,7 @@ client.once(Events.ClientReady, async (c) => {
   registerEntitlementHandlers(c);
 
   // Sync existing entitlements from Discord
-  await syncEntitlementsOnStartup(c);
+  const entitlementSync = await syncEntitlementsOnStartup(c);
 
   // Backfill the one-time Premium trial for guilds that installed the bot before the
   // trial existed — they never fired guildCreate on an eligible code path. Runs last so
@@ -120,12 +120,11 @@ client.once(Events.ClientReady, async (c) => {
   // idempotent by construction. Once the first run has granted the trials, the candidate
   // query returns nothing and every later boot is a no-op with granted=0 — and even a
   // stale candidate is rejected atomically by the WHERE clause inside grantTrialIfEligible.
-  // Awaited (nothing after it depends on it) but wrapped, so a failure never blocks startup.
-  try {
-    await backfillTrials();
-  } catch (error) {
-    console.error('❌ Trial backfill failed:', error);
-  }
+  // Awaited (nothing after it depends on it), and gated on a clean entitlement sync so a
+  // paying guild whose entitlementId failed to write is never mistaken for a FREE trial
+  // candidate. The guard swallows both the skip and any backfill error — see
+  // runStartupTrialBackfill() — so startup is never blocked.
+  await runStartupTrialBackfill(entitlementSync);
 });
 
 // Interaction handler

--- a/src/scripts/backfillTrials.ts
+++ b/src/scripts/backfillTrials.ts
@@ -89,6 +89,37 @@ export async function backfillTrials(
   return { scanned, granted, skipped };
 }
 
+/**
+ * Startup wrapper around {@link backfillTrials} with the entitlement-sync guard.
+ *
+ * `syncEntitlementsOnStartup()` swallows its own errors, so a (partially) failed sync is
+ * indistinguishable from a clean one at the call site unless its result is inspected.
+ * That matters here: the backfill's candidate query treats a NULL `entitlementId` as
+ * "never paid". A guild that IS paying but whose entitlement failed to write would be
+ * picked up as a FREE candidate and handed a trial over its paid tier. So we only run
+ * when the sync completed cleanly; otherwise we skip and let the next boot retry, which
+ * is safe because the backfill is idempotent.
+ *
+ * Never throws — startup must continue regardless.
+ *
+ * @returns the backfill result, or `null` when the backfill was skipped or failed.
+ */
+export async function runStartupTrialBackfill(
+  entitlementSync: { ok: boolean },
+): Promise<BackfillTrialsResult | null> {
+  if (!entitlementSync.ok) {
+    console.warn('⏭️ Trial backfill skipped: entitlement sync did not complete cleanly');
+    return null;
+  }
+
+  try {
+    return await backfillTrials();
+  } catch (error) {
+    console.error('❌ Trial backfill failed:', error);
+    return null;
+  }
+}
+
 if (require.main === module) {
   backfillTrials({ dryRun: process.argv.includes('--dry-run') })
     .then((result) => {

--- a/src/services/entitlementService.ts
+++ b/src/services/entitlementService.ts
@@ -272,14 +272,30 @@ export async function grantTrialIfEligible(guildId: string): Promise<TrialGrantR
 }
 
 /**
+ * Result of the startup entitlement sync.
+ *
+ * `ok` is false whenever the sync did not complete cleanly (missing application ID,
+ * failed REST call, or a failed DB write). Callers that make decisions based on the
+ * *absence* of a paid entitlement — most importantly the trial backfill — must skip
+ * their work when `ok` is false: a guild whose paid entitlement failed to write would
+ * otherwise look like a FREE guild and be handed a trial instead of its paid tier.
+ */
+export interface StartupSyncResult {
+  ok: boolean;
+}
+
+/**
  * Syncs all active entitlements from Discord on startup.
  * Ensures the DB reflects current subscription state even after restarts.
+ *
+ * Never throws — errors are logged and reported via the returned `ok` flag so startup
+ * continues, while downstream steps can still tell a clean sync from a broken one.
  */
-export async function syncEntitlementsOnStartup(client: Client): Promise<void> {
+export async function syncEntitlementsOnStartup(client: Client): Promise<StartupSyncResult> {
   const appId = client.application?.id;
   if (!appId) {
     console.warn('⚠️ Could not sync entitlements: application ID not available');
-    return;
+    return { ok: false };
   }
 
   try {
@@ -315,7 +331,9 @@ export async function syncEntitlementsOnStartup(client: Client): Promise<void> {
     }
 
     console.log(`💎 Startup entitlement sync: ${synced} synced, ${skipped} skipped`);
+    return { ok: true };
   } catch (error) {
     console.error('❌ Failed to sync entitlements on startup:', error);
+    return { ok: false };
   }
 }


### PR DESCRIPTION
## What

Makes the startup trial backfill fail-safe against a failed entitlement sync.

- `syncEntitlementsOnStartup()` now returns `StartupSyncResult` (`{ ok: boolean }`) instead of `void`. It resolves `ok: false` on a missing application ID and on any error it catches — it still never throws.
- New `runStartupTrialBackfill(syncResult)` in `src/scripts/backfillTrials.ts` holds the guard: on a dirty sync it logs `⏭️ Trial backfill skipped: entitlement sync did not complete cleanly` and returns without touching the DB; otherwise it runs `backfillTrials()` and swallows its errors.
- `src/index.ts` ClientReady hook consumes the sync result instead of discarding it.

## Why

Codex post-hoc review, **MAJOR**: the ClientReady hook awaited `syncEntitlementsOnStartup(c)` and then ran `backfillTrials()` unconditionally. Because the sync swallows its own errors internally (`entitlementService.ts`), a partial or total sync failure was invisible to the caller.

The backfill's candidate query treats `entitlementId: null` as "never paid". So a guild that **is** currently paying, but whose `entitlementId` failed to be written by the broken sync, looked like a FREE candidate — and would have been granted a 14-day trial in place of its paid tier.

Skipping is the safe direction: the backfill is idempotent by construction, so the next boot with a clean sync picks up any genuinely eligible legacy guild. The bot starts normally in both cases — no crash, no blocked startup.

**MINOR** (missing regression test) is covered by the tests below.

## Tests

+11 tests, **942 passed** (was 931), 0 failures, 2 skipped. `tsc --noEmit` clean.

- `syncEntitlementsOnStartup()` — `ok: true` for a successful sync, an empty entitlement list, and entitlements skipped for an unknown SKU; `ok: false` for a missing application ID, a failed Discord REST call, and a DB write failure mid-sync; plus an explicit "does not throw" assertion.
- `runStartupTrialBackfill()` — failed sync ⇒ `findMany`/`updateMany` never called and the skip reason is logged; clean sync ⇒ the backfill runs and returns its result; a backfill error ⇒ resolves `null` rather than propagating.

## Scope

No merge, no tag, no deploy.