### PR TITLE
feat(logging): structured one-line log per Discord interaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Collection, Events, ActivityType } from 'discord.js';
+import { Client, GatewayIntentBits, Collection, Events, ActivityType, MessageFlags } from 'discord.js';
 import { config } from 'dotenv';
 import { BotClient, Command } from './types';
 import prisma from './database/client';
@@ -11,6 +11,7 @@ import { buildWelcomeEmbed } from './utils/welcomeEmbed';
 import { getDefaultTeam } from './services/teamService';
 import { TEAM_OPTION_NAME } from './utils/teamContext';
 import { runStartupTrialBackfill } from './scripts/backfillTrials';
+import { logInteraction, commandLabel } from './utils/interactionLog';
 
 config();
 
@@ -128,24 +129,58 @@ client.once(Events.ClientReady, async (c) => {
 });
 
 // Interaction handler
+//
+// Every interaction except autocomplete emits one structured line via logInteraction()
+// so activity is visible in stdout without DB queries. Autocomplete is excluded on
+// purpose: it fires on every keystroke and would drown out the signal.
 client.on(Events.InteractionCreate, async (interaction) => {
+  const startedAt = Date.now();
+
   if (interaction.isChatInputCommand()) {
     const command = client.commands.get(interaction.commandName);
+    const label = commandLabel(interaction);
 
     if (!command) {
       console.error(`Command ${interaction.commandName} not found`);
+      logInteraction({
+        kind: 'CMD',
+        guildId: interaction.guildId,
+        name: label,
+        ok: false,
+        ms: Date.now() - startedAt,
+        err: 'CommandNotFound',
+      });
       return;
     }
 
     try {
       await command.execute(interaction);
+      logInteraction({
+        kind: 'CMD',
+        guildId: interaction.guildId,
+        name: label,
+        ok: true,
+        ms: Date.now() - startedAt,
+      });
     } catch (error) {
+      // The structured line carries the error class; the stack trace stays in the
+      // existing console.error so debugging information is not lost.
+      logInteraction({
+        kind: 'CMD',
+        guildId: interaction.guildId,
+        name: label,
+        ok: false,
+        ms: Date.now() - startedAt,
+        err: error,
+      });
       console.error('Error executing command:', error);
 
+      // `as const` keeps `flags` from widening to the whole MessageFlags enum, which
+      // discord.js's reply options reject.
       const errorMessage = {
         content: '❌ There was an error executing this command!',
-        ephemeral: true,
-      };
+        flags: MessageFlags.Ephemeral,
+      } as const;
 
       if (interaction.replied || interaction.deferred) {
         await interaction.followUp(errorMessage);
@@ -168,18 +203,45 @@ client.on(Events.InteractionCreate, async (interaction) => {
         console.error('Error handling team autocomplete:', error);
       }
     }
-  } else if (interaction.isButton()) {
-    // Import button handler
-    const buttonHandler = await import('./events/buttonHandler');
-    await buttonHandler.handleButton(interaction);
-  } else if (interaction.isModalSubmit()) {
-    // Import modal handler
-    const buttonHandler = await import('./events/buttonHandler');
-    await buttonHandler.handleModalSubmit(interaction);
-  } else if (interaction.isStringSelectMenu()) {
-    // Import select menu handler
-    const selectHandler = await import('./events/selectHandler');
-    await selectHandler.handleSelectMenu(interaction);
+  } else if (interaction.isButton() || interaction.isModalSubmit() || interaction.isStringSelectMenu()) {
+    // Buttons carry the attendance flow (opt-in/opt-out), modals the opt-out reason,
+    // select menus the class/spec picks — all three are activity signals worth logging.
+    const kind = interaction.isButton() ? 'BTN' : interaction.isModalSubmit() ? 'MODAL' : 'SELECT';
+
+    try {
+      if (interaction.isButton()) {
+        const buttonHandler = await import('./events/buttonHandler');
+        await buttonHandler.handleButton(interaction);
+      } else if (interaction.isModalSubmit()) {
+        const buttonHandler = await import('./events/buttonHandler');
+        await buttonHandler.handleModalSubmit(interaction);
+      } else {
+        const selectHandler = await import('./events/selectHandler');
+        await selectHandler.handleSelectMenu(interaction);
+      }
+
+      logInteraction({
+        kind,
+        guildId: interaction.guildId,
+        name: interaction.customId,
+        ok: true,
+        ms: Date.now() - startedAt,
+      });
+    } catch (error) {
+      // These handlers previously ran unguarded, so a throw surfaced only as an
+      // unhandledRejection. Log it in the structured format plus the stack, then
+      // rethrow so no existing behaviour changes.
+      logInteraction({
+        kind,
+        guildId: interaction.guildId,
+        name: interaction.customId,
+        ok: false,
+        ms: Date.now() - startedAt,
+        err: error,
+      });
+      console.error(`Error handling ${kind} interaction:`, error);
+      throw error;
+    }
   }
 });
 

--- a/src/utils/__tests__/interactionLog.test.ts
+++ b/src/utils/__tests__/interactionLog.test.ts
@@ -1,0 +1,261 @@
+import {
+  sanitizeValue,
+  sanitizeCustomId,
+  errorClassName,
+  formatInteractionLog,
+  logInteraction,
+  commandLabel,
+} from '../interactionLog';
+
+describe('sanitizeValue', () => {
+  it('passes through plain command names untouched', () => {
+    expect(sanitizeValue('raid')).toBe('raid');
+    expect(sanitizeValue('raid-create')).toBe('raid-create');
+    expect(sanitizeValue('config:timezone')).toBe('config:timezone');
+  });
+
+  it('keeps guild-id digits intact', () => {
+    expect(sanitizeValue('123456789012345678')).toBe('123456789012345678');
+  });
+
+  it('collapses whitespace so a value can never break the single-line format', () => {
+    expect(sanitizeValue('two words')).toBe('two-words');
+    expect(sanitizeValue('line\nbreak')).toBe('line-break');
+    expect(sanitizeValue('tab\there')).toBe('tab-here');
+  });
+
+  it('strips `=` so key=value parsing stays unambiguous', () => {
+    expect(sanitizeValue('a=b')).not.toContain('=');
+  });
+
+  it('renders nullish and empty input as a placeholder', () => {
+    expect(sanitizeValue(null)).toBe('-');
+    expect(sanitizeValue(undefined)).toBe('-');
+    expect(sanitizeValue('')).toBe('-');
+  });
+
+  it('caps very long values', () => {
+    const out = sanitizeValue('x'.repeat(500));
+    expect(out.length).toBe(65);
+    expect(out.endsWith('~')).toBe(true);
+  });
+});
+
+describe('sanitizeCustomId', () => {
+  it('keeps non-personal customIds fully greppable', () => {
+    expect(sanitizeCustomId('raid_optout_raid-123')).toBe('raid_optout_raid-123');
+    expect(sanitizeCustomId('raid_optin_raid-123')).toBe('raid_optin_raid-123');
+    expect(sanitizeCustomId('spec_select_raid-123_Warrior')).toBe('spec_select_raid-123_Warrior');
+  });
+
+  it('masks the Discord user id embedded in the opt-out reason modal', () => {
+    // Real shape: optout_reason_${raidId}_${userId}
+    const masked = sanitizeCustomId('optout_reason_raid-123_987654321098765432');
+    expect(masked).toBe('optout_reason_raid-123_<id>');
+    expect(masked).not.toContain('987654321098765432');
+  });
+
+  it('masks every snowflake-shaped segment, not just the last', () => {
+    expect(sanitizeCustomId('x_123456789012345678_y_98765432109876543210')).toBe('x_<id>_y_<id>');
+  });
+
+  it('leaves short numeric segments alone (they are not user ids)', () => {
+    expect(sanitizeCustomId('page_2')).toBe('page_2');
+    expect(sanitizeCustomId('raid_1234567890')).toBe('raid_1234567890');
+  });
+
+  it('handles nullish and empty input', () => {
+    expect(sanitizeCustomId(null)).toBe('-');
+    expect(sanitizeCustomId(undefined)).toBe('-');
+    expect(sanitizeCustomId('')).toBe('-');
+  });
+});
+
+describe('errorClassName', () => {
+  class PrismaClientKnownRequestError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'PrismaClientKnownRequestError';
+    }
+  }
+
+  it('reports the error class, never the message', () => {
+    const err = new PrismaClientKnownRequestError('user bob@example.com not found');
+    const out = errorClassName(err);
+    expect(out).toBe('PrismaClientKnownRequestError');
+    expect(out).not.toContain('bob@example.com');
+  });
+
+  it('handles plain Error', () => {
+    expect(errorClassName(new Error('boom'))).toBe('Error');
+  });
+
+  it('accepts a literal class name for synthetic failures', () => {
+    expect(errorClassName('CommandNotFound')).toBe('CommandNotFound');
+  });
+
+  it('handles non-Error throwables without throwing', () => {
+    expect(errorClassName(null)).toBe('UnknownError');
+    expect(errorClassName(undefined)).toBe('UnknownError');
+    expect(errorClassName(42)).toBe('Number');
+    expect(errorClassName({ a: 1 })).toBe('Object');
+    expect(errorClassName(Object.create(null))).toBe('object');
+  });
+});
+
+describe('formatInteractionLog', () => {
+  it('formats a successful command', () => {
+    expect(
+      formatInteractionLog({ kind: 'CMD', guildId: '123', name: 'raid:create', ok: true, ms: 142 })
+    ).toBe('CMD guild=123 cmd=raid:create ok=true ms=142');
+  });
+
+  it('formats a successful button', () => {
+    expect(
+      formatInteractionLog({ kind: 'BTN', guildId: '123', name: 'raid_optout_raid-1', ok: true, ms: 88 })
+    ).toBe('BTN guild=123 id=raid_optout_raid-1 ok=true ms=88');
+  });
+
+  it('appends the error class on failure only', () => {
+    const failed = formatInteractionLog({
+      kind: 'CMD',
+      guildId: '123',
+      name: 'team',
+      ok: false,
+      ms: 310,
+      err: new Error('nope'),
+    });
+    expect(failed).toBe('CMD guild=123 cmd=team ok=false ms=310 err=Error');
+
+    const okLine = formatInteractionLog({ kind: 'CMD', guildId: '1', name: 'team', ok: true, ms: 1, err: new Error('x') });
+    expect(okLine).not.toContain('err=');
+  });
+
+  it('marks DM-context interactions instead of emitting an empty guild', () => {
+    expect(formatInteractionLog({ kind: 'CMD', guildId: null, name: 'stats', ok: true, ms: 5 })).toBe(
+      'CMD guild=dm cmd=stats ok=true ms=5'
+    );
+  });
+
+  it('always emits exactly one line', () => {
+    const line = formatInteractionLog({
+      kind: 'MODAL',
+      guildId: '1\n2',
+      name: 'weird\nid',
+      ok: false,
+      ms: 3,
+      err: new Error('multi\nline'),
+    });
+    expect(line.split('\n')).toHaveLength(1);
+  });
+
+  it('normalises non-finite and negative durations', () => {
+    expect(formatInteractionLog({ kind: 'CMD', guildId: '1', name: 'raid', ok: true, ms: NaN })).toContain('ms=0');
+    expect(formatInteractionLog({ kind: 'CMD', guildId: '1', name: 'raid', ok: true, ms: -5 })).toContain('ms=0');
+    expect(formatInteractionLog({ kind: 'CMD', guildId: '1', name: 'raid', ok: true, ms: 12.7 })).toContain('ms=13');
+  });
+
+  it('never leaks a user id through the customId', () => {
+    const line = formatInteractionLog({
+      kind: 'MODAL',
+      guildId: '123456789012345678',
+      name: 'optout_reason_raid-9_987654321098765432',
+      ok: true,
+      ms: 10,
+    });
+    expect(line).toContain('guild=123456789012345678');
+    expect(line).not.toContain('987654321098765432');
+  });
+});
+
+describe('logInteraction', () => {
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes successes to stdout', () => {
+    logInteraction({ kind: 'CMD', guildId: '123', name: 'raid', ok: true, ms: 7 });
+    expect(logSpy).toHaveBeenCalledWith('CMD guild=123 cmd=raid ok=true ms=7');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes failures to stderr', () => {
+    logInteraction({ kind: 'BTN', guildId: '123', name: 'raid_optin_r1', ok: false, ms: 7, err: new Error('x') });
+    expect(errorSpy).toHaveBeenCalledWith('BTN guild=123 id=raid_optin_r1 ok=false ms=7 err=Error');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('never throws, even on hostile input', () => {
+    const hostile = {
+      kind: 'CMD',
+      guildId: {
+        toString() {
+          throw new Error('boom');
+        },
+      },
+      name: 'raid',
+      ok: true,
+      ms: 1,
+    } as never;
+
+    expect(() => logInteraction(hostile)).not.toThrow();
+  });
+
+  it('never throws when console.log itself explodes', () => {
+    logSpy.mockImplementation(() => {
+      throw new Error('stdout gone');
+    });
+    expect(() => logInteraction({ kind: 'CMD', guildId: '1', name: 'raid', ok: true, ms: 1 })).not.toThrow();
+  });
+});
+
+describe('commandLabel', () => {
+  it('returns the bare name when there is no subcommand', () => {
+    expect(commandLabel({ commandName: 'stats', options: { getSubcommand: () => null, getSubcommandGroup: () => null } })).toBe(
+      'stats'
+    );
+  });
+
+  it('appends subcommand group and subcommand', () => {
+    expect(
+      commandLabel({
+        commandName: 'config',
+        options: { getSubcommandGroup: () => 'roles', getSubcommand: () => 'add' },
+      })
+    ).toBe('config:roles:add');
+  });
+
+  it('appends only the subcommand when there is no group', () => {
+    expect(
+      commandLabel({
+        commandName: 'raid',
+        options: { getSubcommandGroup: () => null, getSubcommand: () => 'create' },
+      })
+    ).toBe('raid:create');
+  });
+
+  it('falls back to the command name when discord.js throws', () => {
+    expect(
+      commandLabel({
+        commandName: 'team',
+        options: {
+          getSubcommandGroup: () => {
+            throw new Error('not a subcommand command');
+          },
+        },
+      })
+    ).toBe('team');
+  });
+
+  it('tolerates a missing options accessor', () => {
+    expect(commandLabel({ commandName: 'raid' })).toBe('raid');
+  });
+});

--- a/src/utils/interactionLog.ts
+++ b/src/utils/interactionLog.ts
@@ -1,0 +1,156 @@
+/**
+ * Structured, single-line logging for Discord interactions.
+ *
+ * Motivation: the bot used to log only errors and guild joins, so a silent log was
+ * ambiguous — an unused bot and a broken-but-quiet bot looked identical, and the
+ * question could only be answered with direct DB queries. One greppable line per
+ * interaction makes "is anyone actually using this?" answerable from stdout.
+ *
+ * Shape (space-separated key=value, always one line):
+ *   CMD guild=123 cmd=raid:create ok=true ms=142
+ *   BTN guild=123 id=raid_optout_raid-123 ok=true ms=88
+ *   CMD guild=123 cmd=team ok=false ms=310 err=PrismaClientKnownRequestError
+ *
+ * Privacy: no usernames, user tags, user IDs, or free-text command input ever reach
+ * this log. Only the guild ID (already logged elsewhere), static command/subcommand
+ * names, and a sanitized customId whose ID-shaped segments are masked.
+ */
+
+/** Interaction kinds we log. Autocomplete is deliberately absent: pure typing noise. */
+export type InteractionLogKind = 'CMD' | 'BTN' | 'MODAL' | 'SELECT';
+
+export interface InteractionLogFields {
+  kind: InteractionLogKind;
+  /** Guild ID, or null/undefined for DM-context interactions. */
+  guildId?: string | null;
+  /** Command name (CMD) or sanitized customId (BTN/MODAL/SELECT). */
+  name?: string | null;
+  ok: boolean;
+  ms: number;
+  /** Error class name; only rendered when ok=false. */
+  err?: unknown;
+}
+
+/** Discord snowflakes are 17-20 digit decimals — mask them wherever they appear. */
+const SNOWFLAKE = /^\d{17,20}$/;
+
+/**
+ * Keep log values to a single parseable token. Allowlist: word characters (incl. `_`,
+ * which customIds are split on) plus `:.<>/-`. Everything else — whitespace, control
+ * characters, quotes, and `=` (which would break naive `key=value` splitting) — is
+ * collapsed into a single `-`.
+ */
+const UNSAFE_VALUE = /[^\w:.<>\/-]+/g;
+
+const MAX_VALUE_LENGTH = 64;
+
+function clamp(value: string): string {
+  return value.length > MAX_VALUE_LENGTH ? `${value.slice(0, MAX_VALUE_LENGTH)}~` : value;
+}
+
+/**
+ * Make an arbitrary string safe to drop into a `key=value` log line: strip whitespace
+ * and control characters, collapse to a single token, cap the length.
+ */
+export function sanitizeValue(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  const text = String(value).replace(UNSAFE_VALUE, '-');
+  return text.length === 0 ? '-' : clamp(text);
+}
+
+/**
+ * Sanitize a component customId for logging.
+ *
+ * Some customIds embed a Discord user ID (e.g. `optout_reason_<raidId>_<userId>`),
+ * which is personal data and must not be logged. Every `_`-separated segment that
+ * looks like a snowflake is replaced with `<id>`, so the *shape* of the interaction
+ * stays greppable while the identity does not survive.
+ */
+export function sanitizeCustomId(customId: unknown): string {
+  if (customId === null || customId === undefined) return '-';
+  const raw = String(customId).replace(UNSAFE_VALUE, '-');
+  if (raw.length === 0) return '-';
+
+  const masked = raw
+    .split('_')
+    .map((segment) => (SNOWFLAKE.test(segment) ? '<id>' : segment))
+    .join('_');
+
+  return clamp(masked);
+}
+
+/** Extract a stable, non-personal error class name. Never throws. */
+export function errorClassName(error: unknown): string {
+  try {
+    if (error === null || error === undefined) return 'UnknownError';
+    // Callers may pass a literal class name for synthetic failures (e.g. CommandNotFound).
+    if (typeof error === 'string') return sanitizeValue(error);
+    if (error instanceof Error) {
+      return sanitizeValue(error.name || error.constructor?.name || 'Error');
+    }
+    const ctor = (error as { constructor?: { name?: string } }).constructor?.name;
+    return sanitizeValue(ctor || typeof error);
+  } catch {
+    return 'UnknownError';
+  }
+}
+
+/** Render a single log line. Pure — no I/O, no throwing. */
+export function formatInteractionLog(fields: InteractionLogFields): string {
+  const kind = fields.kind;
+  const nameKey = kind === 'CMD' ? 'cmd' : 'id';
+  const name = kind === 'CMD' ? sanitizeValue(fields.name) : sanitizeCustomId(fields.name);
+  const guild = fields.guildId ? sanitizeValue(fields.guildId) : 'dm';
+  const ms = Number.isFinite(fields.ms) ? Math.max(0, Math.round(fields.ms)) : 0;
+
+  let line = `${kind} guild=${guild} ${nameKey}=${name} ok=${fields.ok === true} ms=${ms}`;
+  if (fields.ok !== true) {
+    line += ` err=${errorClassName(fields.err)}`;
+  }
+  return line;
+}
+
+/**
+ * Emit one interaction log line. Guaranteed not to throw: logging must never be able
+ * to turn a working command into a failed one, so every failure path here is swallowed.
+ * Failures go to console.error, successes to console.log, so an error-level log filter
+ * still surfaces the bad ones.
+ */
+export function logInteraction(fields: InteractionLogFields): void {
+  try {
+    const line = formatInteractionLog(fields);
+    if (fields.ok === true) {
+      console.log(line);
+    } else {
+      console.error(line);
+    }
+  } catch {
+    // Intentionally silent: a broken log line is never worth failing an interaction.
+  }
+}
+
+/**
+ * Build the `cmd=` value for a chat input command: the command name plus its
+ * subcommand group/subcommand when present (e.g. `config:timezone`). All three are
+ * static, developer-defined names — never user input. Never throws; falls back to the
+ * bare command name if discord.js rejects the accessor.
+ */
+export function commandLabel(interaction: {
+  commandName: string;
+  options?: {
+    // `required: false` matches the discord.js overload that returns `string | null`.
+    getSubcommandGroup?: (required: false) => string | null;
+    getSubcommand?: (required: false) => string | null;
+  };
+}): string {
+  const parts: string[] = [interaction.commandName];
+  try {
+    const group = interaction.options?.getSubcommandGroup?.(false) ?? null;
+    if (group) parts.push(group);
+    const sub = interaction.options?.getSubcommand?.(false) ?? null;
+    if (sub) parts.push(sub);
+  } catch {
+    // Not a subcommand-bearing command — the bare name is the right answer.
+  }
+  return sanitizeValue(parts.join(':'));
+}


### PR DESCRIPTION
## Why

Prod check: the container runs clean (0 restarts, 0 errors in 72h) — but produced **0 log lines in 24h**, because `src/index.ts` only logged errors and guild joins. Successful commands were silent, so "no logs" was ambiguous: idle bot, or broken-but-quiet bot? That question had to be answered with direct DB queries. Now it is answerable from stdout — which also lets us watch whether the 107 premium trials backfilled on 2026-07-28 (running until 2026-08-11) move any needles.

## What

A new helper `src/utils/interactionLog.ts` plus wiring in the `Events.InteractionCreate` handler. One single-line, greppable record per interaction:

```
CMD guild=123456789012345678 cmd=raid:create ok=true ms=142
BTN guild=123456789012345678 id=raid_optout_raid-9f2 ok=true ms=88
MODAL guild=123456789012345678 id=optout_reason_raid-9f2_<id> ok=true ms=64
SELECT guild=123456789012345678 id=spec_select_raid-9f2_Warrior ok=true ms=71
CMD guild=123456789012345678 cmd=team ok=false ms=310 err=PrismaClientKnownRequestError
CMD guild=123456789012345678 cmd=raid ok=false ms=1 err=CommandNotFound
```

(These are the actual outputs of `formatInteractionLog`, not hand-written examples.)

Covered: chat input commands (success, failure, command-not-found), buttons, modal submits, and — trivially, same branch — string select menus, since class/spec picks are part of the same attendance flow. **Autocomplete is deliberately not logged**: it fires per keystroke and would bury the signal.

Successes go to `console.log`, failures to `console.error`, so an error-level filter still surfaces only the bad ones.

## Privacy

No usernames, user tags, user IDs, or free-text command input. Only:
- guild ID (already logged elsewhere),
- static command + subcommand names (`config:roles:add`), never option values,
- customId with every snowflake-shaped (17–20 digit) segment masked to `<id>` — the opt-out reason modal uses `optout_reason_${raidId}_${userId}`, so this is a real leak that is closed and covered by a test.

## Constraints honoured

- No schema change, no migration — pure stdout.
- No new dependency, no logging framework: `console.*` like the rest of the codebase.
- `logInteraction()` is fully wrapped in try/catch and cannot throw, including when `console.log` itself throws (tested). Logging can never turn a working command into a failed one.
- Existing error handling unchanged: the user still gets their error reply, and the existing `console.error` stack traces are **kept** next to the new structured line. Rationale for keeping rather than replacing: the structured line is intentionally identity-free and carries only the error *class*; the stack trace is what you actually debug with. Dropping it would trade a real capability for tidiness.
- The component branch (button/modal/select) previously ran unguarded; the new try/catch logs and then **rethrows**, so failure behaviour is byte-for-byte what it was.

## Bonus

`ephemeral: true` → `flags: MessageFlags.Ephemeral` on the one error reply in the touched handler. No repo-wide sweep.

## Verification

```
$ npm test            # tsc --noEmit
> tsc --noEmit
(exit 0, no output)

$ npx jest
Test Suites: 51 passed, 51 total
Tests:       2 skipped, 973 passed, 975 total

$ npx jest src/utils/__tests__/interactionLog.test.ts
Tests:       31 passed, 31 total
```

31 new unit tests cover formatting, single-line guarantee, snowflake masking, error-class extraction (message never leaked), duration normalisation, DM context, and the no-throw guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)