### PR TITLE
/raid create: interaktiver Modal-Flow statt vier Pflicht-Parametern

### DIFF
--- a/docs/feature-manifest.json
+++ b/docs/feature-manifest.json
@@ -238,8 +238,8 @@
         {
           "name": "create",
           "required": false,
-          "format": "date:<YYYY-MM-DD> time:<HH:MM> title:<text> roles:<role1,role2> [ping_roles:true|false]",
-          "description": "Create a new raid event with date, time, title, and eligible roles"
+          "format": "(no options — guided setup) | [date:<YYYY-MM-DD>] [time:<HH:MM>] [title:<text>] [roles:<role1,role2>] [ping_roles:true|false]",
+          "description": "Create a new raid event. Run without options for a guided flow (modal for name/date/time, then a role picker and a confirmation preview). Supplying all four options creates the raid directly, as before; a partial set pre-fills the modal."
         },
         {
           "name": "list",

--- a/src/commands/__tests__/raid-create.test.ts
+++ b/src/commands/__tests__/raid-create.test.ts
@@ -224,19 +224,38 @@ describe('handleCreateRaid()', () => {
     );
   });
 
+  // The permission check moved ahead of deferReply(): `showModal()` has to be the
+  // first response to an interaction, so the guided flow cannot share a deferred
+  // reply with the one-line path. The rejection is therefore a `reply`, not an
+  // `editReply` — and it must still fire before any raid work happens.
   it('should reject users without permission', async () => {
     (canManageRaids as jest.Mock).mockResolvedValue(false);
     await command.execute(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('permission') })
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('permission'), ephemeral: true })
     );
+    expect(prisma.raid.create).not.toHaveBeenCalled();
   });
 
   it('should reject when member is null', async () => {
     mockInteraction.member = null;
     await command.execute(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('permission') })
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('permission'), ephemeral: true })
+    );
+    expect(prisma.raid.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject a user without permission before opening the guided modal', async () => {
+    (canManageRaids as jest.Mock).mockResolvedValue(false);
+    mockInteraction.showModal = jest.fn();
+    mockInteraction.options.get = jest.fn(() => undefined);
+
+    await command.execute(mockInteraction);
+
+    expect(mockInteraction.showModal).not.toHaveBeenCalled();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('permission'), ephemeral: true })
     );
   });
 
@@ -248,8 +267,10 @@ describe('handleCreateRaid()', () => {
     );
   });
 
-  it('should reject when no raid roles configured and none provided', async () => {
-    (prisma.guild.findUnique as jest.Mock).mockResolvedValueOnce({
+  // Previously this was a dead end ("Raid roles must be specified"). Missing inputs
+  // are now the entry point to the guided flow instead of an error (#38).
+  it('should open the guided modal when roles are missing rather than erroring', async () => {
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
       id: 'guild-123',
       name: 'Test Guild',
       raidRoles: '',
@@ -257,20 +278,22 @@ describe('handleCreateRaid()', () => {
       language: 'en',
       timezone: 'UTC',
     });
-    // Override to provide no roles
-    mockInteraction.options.get = jest.fn((key: string, required?: boolean) => {
+    mockInteraction.showModal = jest.fn();
+    mockInteraction.options.get = jest.fn((key: string) => {
       const values: Record<string, any> = {
         date: { value: futureDateStr() },
         time: { value: '20:00' },
         title: { value: 'Weekly Raid' },
         ping_roles: { value: false },
       };
-      return values[key] !== undefined ? values[key] : (required ? { value: null } : undefined);
+      return values[key];
     });
+
     await command.execute(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('Raid roles must be specified') })
-    );
+
+    expect(mockInteraction.showModal).toHaveBeenCalled();
+    expect(mockInteraction.editReply).not.toHaveBeenCalled();
+    expect(prisma.raid.create).not.toHaveBeenCalled();
   });
 
   it('should reject invalid date/time format', async () => {

--- a/src/commands/__tests__/raid-visibility.test.ts
+++ b/src/commands/__tests__/raid-visibility.test.ts
@@ -291,14 +291,17 @@ describe('/raid visibility & authorization gating', () => {
 
       await command.execute(interaction);
 
-      expect(interaction.editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('do not have permission') })
+      // Rejected via `reply`, not `editReply`: the permission gate now runs before
+      // deferReply() so the guided-modal branch can call showModal() first (#38).
+      // Rejections stay ephemeral so they never leak into the raid channel — now
+      // asserted on the reply itself, since there is no deferral on this path.
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('do not have permission'),
+          ephemeral: true,
+        })
       );
       expect(prisma.raid.create).not.toHaveBeenCalled();
-      // Rejections stay ephemeral so they never leak into the raid channel.
-      expect(interaction.deferReply).toHaveBeenCalledWith(
-        expect.objectContaining({ ephemeral: true })
-      );
     });
 
     it('rejects a member holding only ManageEvents once leader roles are configured', async () => {

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -6,6 +6,8 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  ButtonInteraction,
+  ModalSubmitInteraction,
   Guild,
 } from 'discord.js';
 import prisma from '../database/client';
@@ -27,6 +29,15 @@ import {
   formatInTimezone,
   zonedDateTimeToUtc,
 } from '../utils/timezoneHelper';
+
+/**
+ * Any already-deferred interaction that can carry the raid-creation result back to
+ * the user: the slash command itself, or the confirm button of the modal flow.
+ */
+export type RepliableRaidInteraction =
+  | ChatInputCommandInteraction
+  | ButtonInteraction
+  | ModalSubmitInteraction;
 
 /**
  * Suffix that names the raid's team in a confirmation message.
@@ -179,30 +190,33 @@ const command: Command = {
       addTeamOption(
         subcommand
           .setName('create')
-          .setDescription('Create a new raid event')
+          .setDescription('Create a new raid event — run it without options for a guided setup')
+          // All four inputs are optional so `/raid create` on its own opens the guided
+          // modal flow. Supplying all of them keeps the original one-line behaviour
+          // byte-for-byte; anything in between pre-fills the modal.
           .addStringOption((option) =>
             option
               .setName('date')
-              .setDescription('Raid date (YYYY-MM-DD)')
-              .setRequired(true)
+              .setDescription('Raid date (YYYY-MM-DD) — leave empty for the guided setup')
+              .setRequired(false)
           )
           .addStringOption((option) =>
             option
               .setName('time')
               .setDescription('Raid time (HH:MM in 24h format)')
-              .setRequired(true)
+              .setRequired(false)
           )
           .addStringOption((option) =>
             option
               .setName('title')
               .setDescription('Raid title/name')
-              .setRequired(true)
+              .setRequired(false)
           )
           .addStringOption((option) =>
             option
               .setName('roles')
               .setDescription('Discord roles for this raid (@role mentions or comma-separated names/IDs)')
-              .setRequired(true)
+              .setRequired(false)
           )
           .addBooleanOption((option) =>
             option
@@ -453,22 +467,40 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  const dateStr = interaction.options.get('date', false)?.value as string | undefined;
+  const timeStr = interaction.options.get('time', false)?.value as string | undefined;
+  const title = interaction.options.get('title', false)?.value as string | undefined;
+  const rolesInput = interaction.options.get('roles', false)?.value as string | undefined;
+  const pingRoles = interaction.options.get('ping_roles', false)?.value as boolean ?? false;
 
-  // Check permissions
+  // Permissions are checked before the fork: `showModal()` must be the very first
+  // response to the interaction (it cannot follow a deferReply), so the two branches
+  // cannot share a deferred reply.
   const member = interaction.member;
   if (!member || !(await canManageRaids(member as any))) {
-    await interaction.editReply({
+    await interaction.reply({
       content: '❌ You do not have permission to create raids. Ask your server admin to configure raid leader roles.',
+      ephemeral: true,
     });
     return;
   }
 
-  const dateStr = interaction.options.get('date', true).value as string;
-  const timeStr = interaction.options.get('time', true).value as string;
-  const title = interaction.options.get('title', true).value as string;
-  const rolesInput = interaction.options.get('roles', true).value as string;
-  const pingRoles = interaction.options.get('ping_roles', false)?.value as boolean ?? false;
+  // Anything short of the full four inputs opens the guided flow, pre-filled with
+  // whatever was supplied. Only a complete one-liner takes the direct path.
+  if (!dateStr || !timeStr || !title || !rolesInput) {
+    const { startGuidedRaidCreate } = await import('../events/raidCreateFlow');
+    await startGuidedRaidCreate(interaction, {
+      date: dateStr ?? null,
+      time: timeStr ?? null,
+      title: title ?? null,
+      roles: rolesInput ?? null,
+      pingRoles,
+      teamOption: (interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined) ?? null,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
 
   // Get guild settings first for timezone and default roles
   const guildData = await prisma.guild.findUnique({
@@ -537,20 +569,64 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     return;
   }
 
+  await createRaidWithRoster(interaction, {
+    guild: interaction.guild,
+    channel: interaction.channel,
+    createdBy: interaction.user.id,
+    title,
+    raidDate,
+    roleIds,
+    pingRoles,
+    teamOption: (interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined) ?? null,
+    language: guildData.language || 'en',
+    rolesLabel: effectiveRolesInput,
+  });
+}
+
+/**
+ * Shared tail of raid creation: resolve the roster, enforce the weekly limit, write
+ * the raid, post the public embed and confirm to the caller.
+ *
+ * Extracted so the one-line `/raid create` path and the interactive modal flow
+ * (`events/raidCreateFlow.ts`) produce byte-identical raids instead of drifting
+ * apart. Everything before this point differs only in *how* the four inputs were
+ * collected.
+ *
+ * The interaction must already be deferred ephemerally; this function owns the
+ * final `editReply`. Returns true when a raid was actually created.
+ */
+export async function createRaidWithRoster(
+  interaction: RepliableRaidInteraction,
+  params: {
+    guild: Guild;
+    channel: NonNullable<ChatInputCommandInteraction['channel']>;
+    createdBy: string;
+    title: string;
+    raidDate: Date;
+    roleIds: string[];
+    pingRoles: boolean;
+    teamOption: string | null;
+    language: string;
+    /** Human-readable role list, used only in the "no eligible members" message. */
+    rolesLabel: string;
+  }
+): Promise<boolean> {
+  const { guild, channel, createdBy, title, raidDate, roleIds, pingRoles, teamOption, language, rolesLabel } = params;
+
   let eligibleMembers = new Set<string>();
 
   // Fetch all members if not cached
   try {
-    await interaction.guild.members.fetch();
+    await guild.members.fetch();
   } catch (error) {
     if (isRateLimitError(error)) {
-      await handleRateLimitError(error, interaction, guildData.language || 'en');
-      return;
+      await handleRateLimitError(error, interaction as ChatInputCommandInteraction, language);
+      return false;
     }
     throw error;
   }
 
-  for (const [memberId, member] of interaction.guild.members.cache) {
+  for (const [memberId, member] of guild.members.cache) {
     if (member.user.bot) continue;
 
     const hasRaidRole = member.roles.cache.some((role) =>
@@ -564,20 +640,20 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
 
   if (eligibleMembers.size === 0) {
     await interaction.editReply({
-      content: `❌ No eligible members found with roles: ${effectiveRolesInput}. Verify that members have these roles (use role names or IDs, separated by commas).`,
+      content: `❌ No eligible members found with roles: ${rolesLabel}. Verify that members have these roles (use role names or IDs, separated by commas).`,
     });
-    return;
+    return false;
   }
 
   // Ensure all eligible members have UserPreference records (required for foreign key)
   for (const userId of eligibleMembers) {
-    const member = interaction.guild.members.cache.get(userId);
+    const member = guild.members.cache.get(userId);
     if (member) {
       await prisma.userPreference.upsert({
         where: {
           userId_guildId: {
             userId,
-            guildId: interaction.guild.id,
+            guildId: guild.id,
           },
         },
         update: {
@@ -585,7 +661,7 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
         },
         create: {
           userId,
-          guildId: interaction.guild.id,
+          guildId: guild.id,
           username: member.displayName,
         },
       });
@@ -595,35 +671,34 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   // Get user preferences for class/spec (role-specific preferred over global)
   const memberRolesMap = new Map<string, string[]>();
   for (const userId of eligibleMembers) {
-    const member = interaction.guild.members.cache.get(userId);
+    const member = guild.members.cache.get(userId);
     if (member) {
       memberRolesMap.set(userId, Array.from(member.roles.cache.values()).map(r => r.id));
     }
   }
   const prefsMap = await getEffectivePrefsMap(
     Array.from(eligibleMembers),
-    interaction.guild.id,
+    guild.id,
     roleIds,
     memberRolesMap,
   );
 
   // Resolve the target team before the weekly limit is consumed — an unknown team name is
   // an input error and must not burn a raid slot.
-  const teamOption = interaction.options.get(TEAM_OPTION_NAME, false)?.value as string | undefined;
-  const { team, error: teamError } = await resolveTeam(interaction.guild.id, teamOption ?? null);
+  const { team, error: teamError } = await resolveTeam(guild.id, teamOption);
   if (teamError === 'not_found') {
     await interaction.editReply({
-      content: t(guildData.language || 'en', 'teamNotFound', { name: teamOption ?? '' }),
+      content: t(language, 'teamNotFound', { name: teamOption ?? '' }),
     });
-    return;
+    return false;
   }
 
   // Check weekly raid limit (free tier: 5/week) — after all validation so we don't waste a slot on invalid input.
   // Deliberately guild-wide, not per team: extra teams are a premium convenience and must not
   // multiply the FREE tier's weekly raid allowance.
-  const { allowed, max, resetAt } = await tryConsumeWeeklyRaid(interaction.guild.id);
+  const { allowed, max, resetAt } = await tryConsumeWeeklyRaid(guild.id);
   if (!allowed) {
-    const lang = guildData.language || 'en';
+    const lang = language;
     const localeMap: Record<string, string> = { en: 'en-US', de: 'de-DE' };
     const resetDate = resetAt
       ? resetAt.toLocaleString(localeMap[lang] || 'en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
@@ -631,25 +706,25 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
     await interaction.editReply({
       content: `${t(lang, 'premiumWeeklyLimitReached', { count: String(max), max: String(max), resetDate })}\n${premiumFooterHint(lang)}`,
     });
-    return;
+    return false;
   }
 
   // Create raid in database
   const raid = await prisma.raid.create({
     data: {
-      guildId: interaction.guild.id,
+      guildId: guild.id,
       teamId: team.id,
-      channelId: interaction.channel.id,
+      channelId: channel.id,
       raidDate,
       description: title,
       roles: roleIds.join(','),
-      createdBy: interaction.user.id,
+      createdBy,
     },
   });
 
   // Create attendance records for all eligible members with their saved class/spec
   const attendanceData = Array.from(eligibleMembers).map((userId) => {
-    const member = interaction.guild!.members.cache.get(userId);
+    const member = guild.members.cache.get(userId);
     const pref = prefsMap.get(userId);
     return {
       raidId: raid.id,
@@ -657,7 +732,7 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
       // than the create result so it is never undefined.
       teamId: team.id,
       userId,
-      guildId: interaction.guild!.id,
+      guildId: guild.id,
       username: member?.displayName || 'Unknown',
       status: 'attending' as const,
       wowClass: pref?.wowClass || null,
@@ -670,10 +745,10 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   });
 
   // Create embed with guild's language
-  const embed = await createRaidEmbed(raid.id, guildData.language);
+  const embed = await createRaidEmbed(raid.id, language);
 
   // Get translations for buttons
-  const trans = getTranslations(guildData.language || 'en');
+  const trans = getTranslations(language);
 
   // Create buttons (2 rows due to Discord limit of 5 buttons per row)
   const row1 = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -699,24 +774,24 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   );
 
   // Send public raid message to channel
-  if (!interaction.channel || !('send' in interaction.channel)) {
+  if (!('send' in channel)) {
     await interaction.editReply({
       content: '❌ Cannot send message to this channel type.',
     });
-    return;
+    return false;
   }
 
   // Build role mentions if ping_roles is true
   let content = '';
   if (pingRoles) {
-    const roleMentions = buildRoleMentions(interaction.guild!, roleIds);
+    const roleMentions = buildRoleMentions(guild, roleIds);
     
     if (roleMentions) {
       content = `${roleMentions} - New raid created!`;
     }
   }
 
-  const message = await interaction.channel.send({
+  const message = await channel.send({
     content: content || undefined,
     embeds: [embed],
     components: [row1, row2],
@@ -731,8 +806,10 @@ async function handleCreateRaid(interaction: ChatInputCommandInteraction) {
   // Send ephemeral confirmation to command user — FREE guilds get the premium nudge appended.
   await interaction.editReply({
     content: `✅ Raid "${title}" created successfully with ${eligibleMembers.size} members!`
-      + (await freeTierHint(interaction.guildId, guildData.language || 'en')),
+      + (await freeTierHint(guild.id, language)),
   });
+
+  return true;
 }
 
 export async function createRaidEmbed(raidId: string, language?: string): Promise<EmbedBuilder> {

--- a/src/events/__tests__/raidCreateFlow.test.ts
+++ b/src/events/__tests__/raidCreateFlow.test.ts
@@ -1,0 +1,550 @@
+/**
+ * Tests for the guided `/raid create` flow (issue #38).
+ *
+ * Walks the acceptance criteria: modal on an empty invocation, role select after
+ * submit, preview with Discord timestamps, the time/timezone correction path, and
+ * clean handling of the two ways a user can walk away (expired draft, foreign draft).
+ */
+
+jest.mock('../../database/client');
+jest.mock('../../utils/permissions');
+jest.mock('../../commands/raid', () => ({
+  createRaidWithRoster: jest.fn().mockResolvedValue(true),
+}));
+
+import prisma from '../../database/client';
+import { canManageRaids } from '../../utils/permissions';
+import { createRaidWithRoster } from '../../commands/raid';
+import {
+  __clearDrafts,
+  handleConfirmButton,
+  handleDetailsSubmit,
+  handleFixTimeButton,
+  handleFixTimeSubmit,
+  handleRoleSelect,
+  isFlowButton,
+  isFlowModal,
+  isFlowRoleSelect,
+  startGuidedRaidCreate,
+} from '../raidCreateFlow';
+
+const GUILD_ID = 'guild-123';
+const USER_ID = 'user-leader';
+const CHANNEL_ID = 'channel-123';
+
+/** A date comfortably in the future so "must be in the future" never trips. */
+function futureDate(daysFromNow = 30): string {
+  const d = new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000);
+  return d.toISOString().split('T')[0];
+}
+
+function buildSlashInteraction(overrides: Record<string, any> = {}) {
+  return {
+    guild: { id: GUILD_ID, name: 'Test Guild' },
+    guildId: GUILD_ID,
+    channel: { id: CHANNEL_ID },
+    user: { id: USER_ID },
+    member: {},
+    showModal: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as any;
+}
+
+function buildModalInteraction(customId: string, fields: Record<string, string>, userId = USER_ID) {
+  return {
+    customId,
+    user: { id: userId },
+    guildId: GUILD_ID,
+    fields: {
+      getTextInputValue: (key: string) => {
+        if (!(key in fields)) throw new Error(`no field ${key}`);
+        return fields[key];
+      },
+    },
+    isModalSubmit: () => true,
+    reply: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+function buildRoleSelectInteraction(customId: string, values: string[], userId = USER_ID) {
+  return {
+    customId,
+    values,
+    user: { id: userId },
+    guildId: GUILD_ID,
+    isModalSubmit: () => false,
+    update: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+function buildButtonInteraction(customId: string, userId = USER_ID) {
+  const channelCache = new Map<string, any>();
+  channelCache.set(CHANNEL_ID, { id: CHANNEL_ID, send: jest.fn() });
+
+  return {
+    customId,
+    user: { id: userId },
+    guildId: GUILD_ID,
+    member: {},
+    guild: { id: GUILD_ID, channels: { cache: channelCache } },
+    showModal: jest.fn().mockResolvedValue(undefined),
+    deferUpdate: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+/** Extracts the draft id a step handed to the next one via its custom ID. */
+function draftIdFromModal(interaction: any): string {
+  const modal = interaction.showModal.mock.calls[0][0].toJSON();
+  return modal.custom_id.split(':')[1];
+}
+
+/** Drives modal -> role select and returns the draft id plus both interactions. */
+async function runToRoleSelect(date = futureDate(), time = '20:00', title = 'Heroic Night') {
+  const slash = buildSlashInteraction();
+  await startGuidedRaidCreate(slash, {
+    date: null,
+    time: null,
+    title: null,
+    roles: null,
+    pingRoles: false,
+    teamOption: null,
+  });
+
+  const draftId = draftIdFromModal(slash);
+  const modal = buildModalInteraction(`rcflow-details:${draftId}`, { title, date, time });
+  await handleDetailsSubmit(modal);
+
+  return { draftId, slash, modal };
+}
+
+describe('guided /raid create flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __clearDrafts();
+    (canManageRaids as jest.Mock).mockResolvedValue(true);
+    (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+      id: GUILD_ID,
+      name: 'Test Guild',
+      language: 'en',
+      timezone: 'Europe/Berlin',
+    });
+    (prisma.guild.update as jest.Mock).mockResolvedValue({});
+  });
+
+  describe('step 1 — the modal', () => {
+    it('opens a modal with exactly the three text fields Discord allows here', async () => {
+      const slash = buildSlashInteraction();
+
+      await startGuidedRaidCreate(slash, {
+        date: null,
+        time: null,
+        title: null,
+        roles: null,
+        pingRoles: false,
+        teamOption: null,
+      });
+
+      expect(slash.showModal).toHaveBeenCalled();
+      const modal = slash.showModal.mock.calls[0][0].toJSON();
+      const fieldIds = modal.components.map((row: any) => row.components[0].custom_id);
+      expect(fieldIds).toEqual(['title', 'date', 'time']);
+    });
+
+    // Acceptance criterion: partially filled options must pre-fill, not error.
+    it('pre-fills the modal from partially supplied slash options', async () => {
+      const slash = buildSlashInteraction();
+
+      await startGuidedRaidCreate(slash, {
+        date: null,
+        time: null,
+        title: 'Mythic Prog',
+        roles: null,
+        pingRoles: false,
+        teamOption: null,
+      });
+
+      const modal = slash.showModal.mock.calls[0][0].toJSON();
+      const values = Object.fromEntries(
+        modal.components.map((row: any) => [row.components[0].custom_id, row.components[0].value])
+      );
+      expect(values.title).toBe('Mythic Prog');
+      // The untouched fields still get a usable default rather than being blank.
+      expect(values.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(values.time).toBe('20:00');
+    });
+
+    it('suggests a future default time, never one already past', async () => {
+      const slash = buildSlashInteraction();
+
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+
+      const modal = slash.showModal.mock.calls[0][0].toJSON();
+      const values = Object.fromEntries(
+        modal.components.map((row: any) => [row.components[0].custom_id, row.components[0].value])
+      );
+      // Submitting the untouched defaults must pass the "must be in the future" check.
+      const submit = buildModalInteraction(`rcflow-details:${draftIdFromModal(slash)}`, {
+        title: 'Raid',
+        date: values.date,
+        time: values.time,
+      });
+      await handleDetailsSubmit(submit);
+
+      const content = submit.reply.mock.calls[0][0].content;
+      expect(content).not.toContain('in the past');
+    });
+
+    it('labels the time field with the guild zone so the input is unambiguous', async () => {
+      const slash = buildSlashInteraction();
+
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+
+      const modal = slash.showModal.mock.calls[0][0].toJSON();
+      const timeField = modal.components[2].components[0];
+      expect(timeField.label).toContain('Europe/Berlin');
+    });
+
+    it('refuses outside a guild instead of opening a modal', async () => {
+      const slash = buildSlashInteraction({ guild: null });
+
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+
+      expect(slash.showModal).not.toHaveBeenCalled();
+      expect(slash.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('server'), ephemeral: true })
+      );
+    });
+  });
+
+  describe('step 2 — role select', () => {
+    it('follows the modal with a role select menu', async () => {
+      const { draftId, modal } = await runToRoleSelect();
+
+      const payload = modal.reply.mock.calls[0][0];
+      const component = payload.components[0].toJSON().components[0];
+      expect(component.type).toBe(6); // ROLE_SELECT
+      expect(component.custom_id).toBe(`rcflow-roles:${draftId}`);
+      expect(payload.ephemeral).toBe(true);
+    });
+
+    it('rejects an invalid date without losing the user in a stack trace', async () => {
+      const slash = buildSlashInteraction();
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+      const modal = buildModalInteraction(`rcflow-details:${draftIdFromModal(slash)}`, {
+        title: 'Raid',
+        date: 'next tuesday',
+        time: '20:00',
+      });
+
+      await handleDetailsSubmit(modal);
+
+      expect(modal.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('not a valid date') })
+      );
+    });
+
+    it('rejects a date in the past', async () => {
+      const slash = buildSlashInteraction();
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+      const modal = buildModalInteraction(`rcflow-details:${draftIdFromModal(slash)}`, {
+        title: 'Raid',
+        date: '2020-01-01',
+        time: '20:00',
+      });
+
+      await handleDetailsSubmit(modal);
+
+      expect(modal.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('in the past') })
+      );
+    });
+  });
+
+  describe('step 3 — the preview', () => {
+    it('renders both Discord timestamp forms and the chosen roles', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a', 'role-b']);
+
+      await handleRoleSelect(select);
+
+      const embed = select.update.mock.calls[0][0].embeds[0].toJSON();
+      // Acceptance criterion: absolute *and* relative timestamp.
+      expect(embed.description).toMatch(/<t:\d+:F>/);
+      expect(embed.description).toMatch(/<t:\d+:R>/);
+      expect(embed.description).toContain('<@&role-a>');
+      expect(embed.description).toContain('<@&role-b>');
+    });
+
+    it('names the zone the time was entered in, so a wrong zone is visible', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+
+      await handleRoleSelect(select);
+
+      const embed = select.update.mock.calls[0][0].embeds[0].toJSON();
+      expect(embed.description).toContain('Europe/Berlin');
+    });
+
+    it('offers a confirm and a correct-time button', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+
+      await handleRoleSelect(select);
+
+      const buttons = select.update.mock.calls[0][0].components[0].toJSON().components;
+      expect(buttons.map((b: any) => b.custom_id)).toEqual([
+        `rcflow-confirm:${draftId}`,
+        `rcflow-fixtime:${draftId}`,
+      ]);
+    });
+
+    it('converts the typed time using the guild zone, with DST applied', async () => {
+      // Same wall-clock time, opposite seasons: the rendered unix timestamps must
+      // differ by the DST hour, not by a fixed offset.
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+        id: GUILD_ID, language: 'en', timezone: 'Europe/Berlin',
+      });
+
+      const unixFor = async (date: string) => {
+        __clearDrafts();
+        const { draftId } = await runToRoleSelect(date, '20:00');
+        const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+        await handleRoleSelect(select);
+        const embed = select.update.mock.calls[0][0].embeds[0].toJSON();
+        return Number(embed.description.match(/<t:(\d+):F>/)[1]);
+      };
+
+      const winter = await unixFor('2035-01-17');
+      const summer = await unixFor('2035-07-17');
+
+      expect(new Date(winter * 1000).toISOString()).toBe('2035-01-17T19:00:00.000Z'); // CET
+      expect(new Date(summer * 1000).toISOString()).toBe('2035-07-17T18:00:00.000Z'); // CEST
+    });
+  });
+
+  describe('step 4 — fix time / timezone', () => {
+    it('opens a modal pre-filled with the current draft and guild zone', async () => {
+      const { draftId } = await runToRoleSelect();
+      const button = buildButtonInteraction(`rcflow-fixtime:${draftId}`);
+
+      await handleFixTimeButton(button);
+
+      const modal = button.showModal.mock.calls[0][0].toJSON();
+      const values = Object.fromEntries(
+        modal.components.map((row: any) => [row.components[0].custom_id, row.components[0].value])
+      );
+      expect(values.timezone).toBe('Europe/Berlin');
+      expect(values.time).toBe('20:00');
+    });
+
+    // Acceptance criterion: correcting the time persists the guild zone, so the
+    // next raid is right without anyone visiting /config.
+    it('persists the corrected zone on the guild', async () => {
+      const { draftId } = await runToRoleSelect();
+      const submit = buildModalInteraction(`rcflow-fixtime-modal:${draftId}`, {
+        date: futureDate(),
+        time: '20:00',
+        timezone: 'America/New_York',
+      });
+
+      await handleFixTimeSubmit(submit);
+
+      expect(prisma.guild.update).toHaveBeenCalledWith({
+        where: { id: GUILD_ID },
+        data: { timezone: 'America/New_York' },
+      });
+    });
+
+    it('rejects an unknown zone without touching the guild row', async () => {
+      const { draftId } = await runToRoleSelect();
+      const submit = buildModalInteraction(`rcflow-fixtime-modal:${draftId}`, {
+        date: futureDate(),
+        time: '20:00',
+        timezone: 'Mordor/Barad-dur',
+      });
+
+      await handleFixTimeSubmit(submit);
+
+      expect(prisma.guild.update).not.toHaveBeenCalled();
+      expect(submit.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('not a known timezone') })
+      );
+    });
+
+    it('re-renders the preview after a successful correction', async () => {
+      const { draftId } = await runToRoleSelect();
+      const submit = buildModalInteraction(`rcflow-fixtime-modal:${draftId}`, {
+        date: futureDate(),
+        time: '21:30',
+        timezone: 'Europe/Berlin',
+      });
+
+      await handleFixTimeSubmit(submit);
+
+      const embed = submit.reply.mock.calls[0][0].embeds[0].toJSON();
+      expect(embed.description).toMatch(/<t:\d+:F>/);
+    });
+  });
+
+  describe('step 5 — confirm', () => {
+    async function runToPreview() {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+      await handleRoleSelect(select);
+      return draftId;
+    }
+
+    it('creates the raid through the same path as the one-line command', async () => {
+      const draftId = await runToPreview();
+      const button = buildButtonInteraction(`rcflow-confirm:${draftId}`);
+
+      await handleConfirmButton(button);
+
+      expect(createRaidWithRoster).toHaveBeenCalledWith(
+        button,
+        expect.objectContaining({
+          title: 'Heroic Night',
+          roleIds: ['role-a'],
+          createdBy: USER_ID,
+        })
+      );
+    });
+
+    // A double-click on an ephemeral button is easy; two raids from one flow is not
+    // acceptable, so the draft is consumed before the write.
+    it('creates only one raid when the confirm button is clicked twice', async () => {
+      const draftId = await runToPreview();
+
+      await handleConfirmButton(buildButtonInteraction(`rcflow-confirm:${draftId}`));
+      await handleConfirmButton(buildButtonInteraction(`rcflow-confirm:${draftId}`));
+
+      expect(createRaidWithRoster).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-checks permissions at confirm time, not just at command time', async () => {
+      const draftId = await runToPreview();
+      // The user lost their leader role while the preview was on screen.
+      (canManageRaids as jest.Mock).mockResolvedValue(false);
+      const button = buildButtonInteraction(`rcflow-confirm:${draftId}`);
+
+      await handleConfirmButton(button);
+
+      expect(createRaidWithRoster).not.toHaveBeenCalled();
+      expect(button.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('permission') })
+      );
+    });
+
+    it('refuses when the raid time has slipped into the past', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+      await handleRoleSelect(select);
+
+      // Simulate the clock moving past the raid by rewriting the draft through the
+      // correction path is not possible (it validates too), so assert via a draft
+      // whose date was valid at entry: jump the clock instead.
+      const realNow = Date.now;
+      Date.now = () => realNow() + 400 * 24 * 60 * 60 * 1000;
+      try {
+        const button = buildButtonInteraction(`rcflow-confirm:${draftId}`);
+        await handleConfirmButton(button);
+        expect(createRaidWithRoster).not.toHaveBeenCalled();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('abandoned and hijacked flows', () => {
+    it('tells the user plainly when the draft has expired', async () => {
+      const modal = buildModalInteraction('rcflow-details:doesnotexist', {
+        title: 'Raid',
+        date: futureDate(),
+        time: '20:00',
+      });
+
+      await handleDetailsSubmit(modal);
+
+      expect(modal.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('clears the stale components when an expired draft is confirmed', async () => {
+      const button = buildButtonInteraction('rcflow-confirm:doesnotexist');
+
+      await handleConfirmButton(button);
+
+      expect(button.update).toHaveBeenCalledWith(
+        expect.objectContaining({ components: [], embeds: [] })
+      );
+      expect(createRaidWithRoster).not.toHaveBeenCalled();
+    });
+
+    // Custom IDs are visible to anyone who can read the message.
+    it('refuses to act on another user\'s draft', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a'], 'someone-else');
+
+      await handleRoleSelect(select);
+
+      expect(select.update).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('does not create a raid from another user\'s confirm click', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+      await handleRoleSelect(select);
+
+      await handleConfirmButton(buildButtonInteraction(`rcflow-confirm:${draftId}`, 'someone-else'));
+
+      expect(createRaidWithRoster).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dispatch predicates', () => {
+    it('claims its own custom IDs', () => {
+      expect(isFlowModal('rcflow-details:d1')).toBe(true);
+      expect(isFlowModal('rcflow-fixtime-modal:d1')).toBe(true);
+      expect(isFlowButton('rcflow-confirm:d1')).toBe(true);
+      expect(isFlowButton('rcflow-fixtime:d1')).toBe(true);
+      expect(isFlowRoleSelect('rcflow-roles:d1')).toBe(true);
+    });
+
+    it('leaves the existing attendance handlers alone', () => {
+      // These belong to buttonHandler/selectHandler and must not be intercepted.
+      expect(isFlowModal('optout_reason_raid1_user1')).toBe(false);
+      expect(isFlowButton('raid_optin_raid1')).toBe(false);
+      expect(isFlowButton('raid_optout_raid1')).toBe(false);
+      expect(isFlowRoleSelect('class_select_raid1')).toBe(false);
+    });
+
+    // Draft ids must survive the `split('_')` convention used by the older handlers.
+    it('generates draft ids free of underscores', async () => {
+      const slash = buildSlashInteraction();
+      await startGuidedRaidCreate(slash, {
+        date: null, time: null, title: null, roles: null, pingRoles: false, teamOption: null,
+      });
+
+      expect(draftIdFromModal(slash)).not.toContain('_');
+    });
+  });
+});

--- a/src/events/__tests__/raidCreateFlow.test.ts
+++ b/src/events/__tests__/raidCreateFlow.test.ts
@@ -365,9 +365,11 @@ describe('guided /raid create flow', () => {
 
       await handleFixTimeSubmit(submit);
 
+      // The deprecated timezoneOffset column rides along until phase 2 of the IANA
+      // migration drops it — see guildTimezoneUpdate().
       expect(prisma.guild.update).toHaveBeenCalledWith({
         where: { id: GUILD_ID },
-        data: { timezone: 'America/New_York' },
+        data: { timezone: 'America/New_York', timezoneOffset: expect.any(Number) },
       });
     });
 

--- a/src/events/raidCreateFlow.ts
+++ b/src/events/raidCreateFlow.ts
@@ -39,6 +39,7 @@ import {
   DEFAULT_TIMEZONE,
   formatInTimezone,
   formatTimezoneLabel,
+  guildTimezoneUpdate,
   normalizeTimezone,
   zonedDateTimeToUtc,
 } from '../utils/timezoneHelper';
@@ -442,7 +443,7 @@ export async function handleFixTimeSubmit(interaction: ModalSubmitInteraction): 
   // preview is that fixing it once fixes every future raid.
   await prisma.guild.update({
     where: { id: draft.guildId },
-    data: { timezone },
+    data: guildTimezoneUpdate(timezone),
   });
 
   draft.date = date;

--- a/src/events/raidCreateFlow.ts
+++ b/src/events/raidCreateFlow.ts
@@ -1,0 +1,558 @@
+/**
+ * Guided `/raid create` flow: modal → role select → preview → confirm.
+ *
+ * `/raid create` used to demand four free-text parameters in a single slash-command
+ * line (date, time, title, roles), with no choices and no native option types. That
+ * is the wall 88 of 108 guilds never got past — they installed the bot and never
+ * created a raid. This module is the low-friction path; the one-line form still
+ * works unchanged for anyone who already knows it (see `handleCreateRaid`).
+ *
+ * Discord constrains the shape of this flow:
+ *   - `showModal()` must be the first response to an interaction, so the fork
+ *     happens before any `deferReply()`.
+ *   - Modals hold text inputs only. Roles therefore cannot live in the modal and
+ *     need a follow-up `RoleSelectMenu`.
+ *   - Custom IDs are split on `_` elsewhere in the codebase, and IANA zone names
+ *     contain underscores (`America/New_York`). Nothing but an opaque draft id
+ *     goes into a custom ID here.
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Guild,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  RoleSelectMenuBuilder,
+  RoleSelectMenuInteraction,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import prisma from '../database/client';
+import { createRaidWithRoster } from '../commands/raid';
+import { canManageRaids } from '../utils/permissions';
+import {
+  DEFAULT_TIMEZONE,
+  formatInTimezone,
+  formatTimezoneLabel,
+  normalizeTimezone,
+  zonedDateTimeToUtc,
+} from '../utils/timezoneHelper';
+
+/** Discord invalidates an interaction token after 15 minutes; drafts die with it. */
+const DRAFT_TTL_MS = 15 * 60 * 1000;
+
+export const MODAL_DETAILS = 'rcflow-details';
+// Distinct from BUTTON_FIXTIME: the button opens this modal, and although the two
+// interaction types never collide in dispatch, sharing a literal reads like a bug.
+export const MODAL_FIXTIME = 'rcflow-fixtime-modal';
+export const SELECT_ROLES = 'rcflow-roles';
+export const BUTTON_CONFIRM = 'rcflow-confirm';
+export const BUTTON_FIXTIME = 'rcflow-fixtime';
+
+interface RaidDraft {
+  guildId: string;
+  userId: string;
+  channelId: string;
+  date: string;
+  time: string;
+  title: string;
+  roleIds: string[];
+  pingRoles: boolean;
+  teamOption: string | null;
+  createdAt: number;
+}
+
+/**
+ * In-memory draft store.
+ *
+ * Deliberately not a database table: a draft is meaningless once the interaction
+ * token expires (15 min), so persisting it would add a migration and a cleanup job
+ * to store rows that can never be used again. The trade-off is that drafts do not
+ * survive a bot restart — the user sees "session expired" and re-runs the command.
+ * This assumes a single bot process, which is how RaidPresence is deployed.
+ */
+const drafts = new Map<string, RaidDraft>();
+
+function pruneExpiredDrafts(now: number): void {
+  for (const [id, draft] of drafts) {
+    if (now - draft.createdAt > DRAFT_TTL_MS) drafts.delete(id);
+  }
+}
+
+/** Opaque, collision-free draft id. Contains no `_` so custom-ID splitting is safe. */
+let draftCounter = 0;
+function newDraftId(): string {
+  draftCounter = (draftCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return `d${Date.now().toString(36)}${draftCounter.toString(36)}`;
+}
+
+function putDraft(draft: Omit<RaidDraft, 'createdAt'>): string {
+  const now = Date.now();
+  pruneExpiredDrafts(now);
+  const id = newDraftId();
+  drafts.set(id, { ...draft, createdAt: now });
+  return id;
+}
+
+function getDraft(id: string, userId: string): RaidDraft | null {
+  pruneExpiredDrafts(Date.now());
+  const draft = drafts.get(id);
+  if (!draft) return null;
+  // A custom ID is visible to anyone who can see the message; never act on someone
+  // else's draft.
+  if (draft.userId !== userId) return null;
+  return draft;
+}
+
+/** Exposed for tests — the store is module-level state. */
+export function __clearDrafts(): void {
+  drafts.clear();
+}
+
+async function guildTimezone(guildId: string): Promise<string> {
+  const guild = await prisma.guild.findUnique({ where: { id: guildId } });
+  return guild?.timezone || DEFAULT_TIMEZONE;
+}
+
+/**
+ * Suggests a sensible default date/time for the modal: the next occurrence of 20:00
+ * in the guild's zone, so a raid leader can submit the form without typing anything
+ * beyond a title.
+ */
+function defaultDateTime(timezone: string, now: Date = new Date()): { date: string; time: string } {
+  const today = formatInTimezone(now, timezone);
+  const todayAt20 = zonedDateTimeToUtc(today.date, '20:00', timezone);
+
+  if (todayAt20 && todayAt20 > now) return { date: today.date, time: '20:00' };
+
+  const tomorrow = formatInTimezone(new Date(now.getTime() + 24 * 60 * 60 * 1000), timezone);
+  return { date: tomorrow.date, time: '20:00' };
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — the modal
+// ---------------------------------------------------------------------------
+
+export async function startGuidedRaidCreate(
+  interaction: ChatInputCommandInteraction,
+  prefill: {
+    date: string | null;
+    time: string | null;
+    title: string | null;
+    roles: string | null;
+    pingRoles: boolean;
+    teamOption: string | null;
+  }
+): Promise<void> {
+  if (!interaction.guild || !interaction.channel) {
+    await interaction.reply({
+      content: '❌ This command can only be used in a server!',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const timezone = await guildTimezone(interaction.guild.id);
+  const fallback = defaultDateTime(timezone);
+
+  // The draft is created up front so the modal's custom ID can carry it. Roles are
+  // filled in at the select step; anything passed on the command line is preserved.
+  const draftId = putDraft({
+    guildId: interaction.guild.id,
+    userId: interaction.user.id,
+    channelId: interaction.channel.id,
+    date: prefill.date ?? fallback.date,
+    time: prefill.time ?? fallback.time,
+    title: prefill.title ?? '',
+    roleIds: [],
+    pingRoles: prefill.pingRoles,
+    teamOption: prefill.teamOption,
+  });
+
+  const modal = new ModalBuilder()
+    .setCustomId(`${MODAL_DETAILS}:${draftId}`)
+    .setTitle('Create a raid')
+    .addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('title')
+          .setLabel('Raid name')
+          .setPlaceholder('Heroic Raid Night')
+          .setStyle(TextInputStyle.Short)
+          .setMaxLength(100)
+          .setValue(prefill.title ?? '')
+          .setRequired(true)
+      ),
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('date')
+          .setLabel('Date (YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(prefill.date ?? fallback.date)
+          .setRequired(true)
+      ),
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('time')
+          .setLabel(`Time (HH:MM, ${timezone})`)
+          .setStyle(TextInputStyle.Short)
+          .setValue(prefill.time ?? fallback.time)
+          .setRequired(true)
+      )
+    );
+
+  await interaction.showModal(modal);
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — modal submit, then the role picker
+// ---------------------------------------------------------------------------
+
+export async function handleDetailsSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.reply({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const title = interaction.fields.getTextInputValue('title').trim();
+  const date = interaction.fields.getTextInputValue('date').trim();
+  const time = interaction.fields.getTextInputValue('time').trim();
+
+  const timezone = await guildTimezone(draft.guildId);
+  const raidDate = zonedDateTimeToUtc(date, time, timezone);
+
+  if (!raidDate) {
+    await interaction.reply({
+      content:
+        `❌ \`${date} ${time}\` is not a valid date and time.\n` +
+        'Use `YYYY-MM-DD` for the date and `HH:MM` (24h) for the time — for example ' +
+        '`2026-08-14` and `20:00`. Run `/raid create` to try again.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (raidDate < new Date()) {
+    await interaction.reply({
+      content: '❌ That is in the past. Run `/raid create` again and pick a future date.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  draft.title = title;
+  draft.date = date;
+  draft.time = time;
+
+  const select = new RoleSelectMenuBuilder()
+    .setCustomId(`${SELECT_ROLES}:${draftId}`)
+    .setPlaceholder('Which roles are raiding?')
+    .setMinValues(1)
+    .setMaxValues(10);
+
+  await interaction.reply({
+    content:
+      `**${title}** — <t:${Math.floor(raidDate.getTime() / 1000)}:F>\n\n` +
+      'Now pick the roles whose members should be on the roster. ' +
+      'Everyone with those roles is signed up automatically and only has to opt *out*.',
+    components: [new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(select)],
+    ephemeral: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — role select, then the preview
+// ---------------------------------------------------------------------------
+
+export async function handleRoleSelect(interaction: RoleSelectMenuInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.update({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      components: [],
+    });
+    return;
+  }
+
+  draft.roleIds = [...interaction.values];
+
+  await showPreview(interaction, draftId, draft);
+}
+
+/**
+ * The confirmation preview.
+ *
+ * `<t:unix:F>` renders in the *viewer's* own Discord timezone, so a raid leader
+ * whose guild zone is wrong sees it here — immediately — instead of discovering it
+ * three days later when nobody shows up. That is what makes the zone setting
+ * self-correcting, and it is why issue #37 deferred this piece to this flow.
+ */
+async function showPreview(
+  interaction: RoleSelectMenuInteraction | ModalSubmitInteraction,
+  draftId: string,
+  draft: RaidDraft
+): Promise<void> {
+  const timezone = await guildTimezone(draft.guildId);
+  const raidDate = zonedDateTimeToUtc(draft.date, draft.time, timezone)!;
+  const unix = Math.floor(raidDate.getTime() / 1000);
+
+  const embed = new EmbedBuilder()
+    .setTitle(`📋 ${draft.title}`)
+    .setColor(0x00ae86)
+    .setDescription(
+      `**When:** <t:${unix}:F> (<t:${unix}:R>)\n` +
+      `**Roles:** ${draft.roleIds.map((id) => `<@&${id}>`).join(' ')}\n\n` +
+      `_Entered as ${draft.time} in ${formatTimezoneLabel(timezone)}. ` +
+      'The time above is shown in your own Discord timezone — if it looks wrong, ' +
+      'fix the server timezone below._'
+    );
+
+  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${BUTTON_CONFIRM}:${draftId}`)
+      .setLabel('Create raid')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`${BUTTON_FIXTIME}:${draftId}`)
+      .setLabel('Fix time / timezone')
+      .setStyle(ButtonStyle.Secondary)
+  );
+
+  const payload = { content: '', embeds: [embed], components: [buttons] };
+
+  if (interaction.isModalSubmit()) {
+    await interaction.reply({ ...payload, ephemeral: true });
+  } else {
+    await interaction.update(payload);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 4a — "Fix time / timezone"
+// ---------------------------------------------------------------------------
+
+export async function handleFixTimeButton(interaction: ButtonInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.update({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  const timezone = await guildTimezone(draft.guildId);
+
+  const modal = new ModalBuilder()
+    .setCustomId(`${MODAL_FIXTIME}:${draftId}`)
+    .setTitle('Fix time / timezone')
+    .addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('date')
+          .setLabel('Date (YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(draft.date)
+          .setRequired(true)
+      ),
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('time')
+          .setLabel('Time (HH:MM, 24h)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(draft.time)
+          .setRequired(true)
+      ),
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('timezone')
+          .setLabel('Server timezone (IANA)')
+          .setPlaceholder('Europe/Berlin')
+          .setStyle(TextInputStyle.Short)
+          .setValue(timezone)
+          .setRequired(true)
+      )
+    );
+
+  await interaction.showModal(modal);
+}
+
+export async function handleFixTimeSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.reply({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const date = interaction.fields.getTextInputValue('date').trim();
+  const time = interaction.fields.getTextInputValue('time').trim();
+  const zoneInput = interaction.fields.getTextInputValue('timezone').trim();
+
+  const timezone = normalizeTimezone(zoneInput);
+  if (!timezone) {
+    await interaction.reply({
+      content:
+        `❌ \`${zoneInput}\` is not a known timezone. Use an IANA name such as ` +
+        '`Europe/Berlin`, `America/New_York` or `UTC`, then press ' +
+        '**Fix time / timezone** again.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const raidDate = zonedDateTimeToUtc(date, time, timezone);
+  if (!raidDate) {
+    await interaction.reply({
+      content: `❌ \`${date} ${time}\` is not a valid date and time. Use \`YYYY-MM-DD\` and \`HH:MM\`.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (raidDate < new Date()) {
+    await interaction.reply({
+      content: '❌ That is in the past. Press **Fix time / timezone** again and pick a future date.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // Persist the corrected zone for the guild — the whole point of surfacing the
+  // preview is that fixing it once fixes every future raid.
+  await prisma.guild.update({
+    where: { id: draft.guildId },
+    data: { timezone },
+  });
+
+  draft.date = date;
+  draft.time = time;
+
+  await showPreview(interaction, draftId, draft);
+}
+
+// ---------------------------------------------------------------------------
+// Step 4b — "Create raid"
+// ---------------------------------------------------------------------------
+
+export async function handleConfirmButton(interaction: ButtonInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.update({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  await interaction.deferUpdate();
+
+  // Re-check permissions at the point of the write: roles can change between opening
+  // the flow and confirming it.
+  if (!interaction.member || !(await canManageRaids(interaction.member as any))) {
+    await interaction.editReply({
+      content: '❌ You do not have permission to create raids.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  const guild = interaction.guild as Guild | null;
+  const channel = guild ? guild.channels.cache.get(draft.channelId) : null;
+
+  if (!guild || !channel) {
+    await interaction.editReply({
+      content: '❌ The channel this raid was started in is no longer available.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  const guildData = await prisma.guild.findUnique({ where: { id: draft.guildId } });
+  const timezone = guildData?.timezone || DEFAULT_TIMEZONE;
+  const raidDate = zonedDateTimeToUtc(draft.date, draft.time, timezone);
+
+  if (!raidDate || raidDate < new Date()) {
+    await interaction.editReply({
+      content: '❌ That raid time is no longer in the future. Run `/raid create` again.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  // Clear the draft before the write so a double-click cannot create two raids.
+  drafts.delete(draftId);
+
+  await interaction.editReply({ content: '⏳ Creating the raid…', embeds: [], components: [] });
+
+  await createRaidWithRoster(interaction, {
+    guild,
+    channel: channel as any,
+    createdBy: draft.userId,
+    title: draft.title,
+    raidDate,
+    roleIds: draft.roleIds,
+    pingRoles: draft.pingRoles,
+    teamOption: draft.teamOption,
+    language: guildData?.language || 'en',
+    rolesLabel: draft.roleIds.map((id) => `<@&${id}>`).join(', '),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch helpers — keep the customId prefixes in one place
+// ---------------------------------------------------------------------------
+
+export function isFlowModal(customId: string): boolean {
+  return customId.startsWith(`${MODAL_DETAILS}:`) || customId.startsWith(`${MODAL_FIXTIME}:`);
+}
+
+export function isFlowButton(customId: string): boolean {
+  return customId.startsWith(`${BUTTON_CONFIRM}:`) || customId.startsWith(`${BUTTON_FIXTIME}:`);
+}
+
+export function isFlowRoleSelect(customId: string): boolean {
+  return customId.startsWith(`${SELECT_ROLES}:`);
+}
+
+export async function routeFlowModal(interaction: ModalSubmitInteraction): Promise<void> {
+  if (interaction.customId.startsWith(`${MODAL_DETAILS}:`)) {
+    await handleDetailsSubmit(interaction);
+  } else {
+    await handleFixTimeSubmit(interaction);
+  }
+}
+
+export async function routeFlowButton(interaction: ButtonInteraction): Promise<void> {
+  if (interaction.customId.startsWith(`${BUTTON_CONFIRM}:`)) {
+    await handleConfirmButton(interaction);
+  } else {
+    await handleFixTimeButton(interaction);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,18 +193,44 @@ client.on(Events.InteractionCreate, async (interaction) => {
         console.error('Error handling timezone autocomplete:', error);
       }
     }
-  } else if (interaction.isButton() || interaction.isModalSubmit() || interaction.isStringSelectMenu()) {
-    // Buttons carry the attendance flow (opt-in/opt-out), modals the opt-out reason,
-    // select menus the class/spec picks — all three are activity signals worth logging.
-    const kind = interaction.isButton() ? 'BTN' : interaction.isModalSubmit() ? 'MODAL' : 'SELECT';
+  } else if (
+    interaction.isButton() ||
+    interaction.isModalSubmit() ||
+    interaction.isStringSelectMenu() ||
+    interaction.isRoleSelectMenu()
+  ) {
+    // Buttons carry the attendance flow (opt-in/opt-out) and the guided raid-create
+    // confirmation, modals the opt-out reason and the raid-create details, string
+    // selects the class/spec picks, role selects the raid roster roles. All are
+    // activity signals worth logging — the guided flow especially, since the whole
+    // point of #38 is being able to see where people drop out.
+    const kind = interaction.isButton()
+      ? 'BTN'
+      : interaction.isModalSubmit()
+      ? 'MODAL'
+      : 'SELECT';
 
     try {
+      const flow = await import('./events/raidCreateFlow');
+
       if (interaction.isButton()) {
-        const buttonHandler = await import('./events/buttonHandler');
-        await buttonHandler.handleButton(interaction);
+        if (flow.isFlowButton(interaction.customId)) {
+          await flow.routeFlowButton(interaction);
+        } else {
+          const buttonHandler = await import('./events/buttonHandler');
+          await buttonHandler.handleButton(interaction);
+        }
       } else if (interaction.isModalSubmit()) {
-        const buttonHandler = await import('./events/buttonHandler');
-        await buttonHandler.handleModalSubmit(interaction);
+        if (flow.isFlowModal(interaction.customId)) {
+          await flow.routeFlowModal(interaction);
+        } else {
+          const buttonHandler = await import('./events/buttonHandler');
+          await buttonHandler.handleModalSubmit(interaction);
+        }
+      } else if (interaction.isRoleSelectMenu()) {
+        if (flow.isFlowRoleSelect(interaction.customId)) {
+          await flow.handleRoleSelect(interaction);
+        }
       } else {
         const selectHandler = await import('./events/selectHandler');
         await selectHandler.handleSelectMenu(interaction);

--- a/src/utils/__tests__/interactionLog.test.ts
+++ b/src/utils/__tests__/interactionLog.test.ts
@@ -42,6 +42,28 @@ describe('sanitizeValue', () => {
 });
 
 describe('sanitizeCustomId', () => {
+  // The guided raid-create flow (#38) carries a per-flow draft id after a colon.
+  // It must collapse to a constant, otherwise every step logs a unique name and
+  // "how many people abandon at the role picker?" becomes uncountable.
+  describe('guided raid-create flow', () => {
+    it('masks the per-flow draft id so steps aggregate', () => {
+      expect(sanitizeCustomId('rcflow-details:dm3x9a1')).toBe('rcflow-details:<id>');
+      expect(sanitizeCustomId('rcflow-roles:dm3x9a1')).toBe('rcflow-roles:<id>');
+      expect(sanitizeCustomId('rcflow-confirm:dm3x9a1')).toBe('rcflow-confirm:<id>');
+      expect(sanitizeCustomId('rcflow-fixtime:dm3x9a1')).toBe('rcflow-fixtime:<id>');
+    });
+
+    it('collapses two different drafts of the same step to one log name', () => {
+      expect(sanitizeCustomId('rcflow-confirm:dabc123')).toBe(
+        sanitizeCustomId('rcflow-confirm:dxyz789')
+      );
+    });
+
+    it('still distinguishes the steps from each other', () => {
+      expect(sanitizeCustomId('rcflow-roles:d1')).not.toBe(sanitizeCustomId('rcflow-confirm:d1'));
+    });
+  });
+
   it('keeps non-personal customIds fully greppable', () => {
     expect(sanitizeCustomId('raid_optout_raid-123')).toBe('raid_optout_raid-123');
     expect(sanitizeCustomId('raid_optin_raid-123')).toBe('raid_optin_raid-123');

--- a/src/utils/interactionLog.ts
+++ b/src/utils/interactionLog.ts
@@ -65,18 +65,26 @@ export function sanitizeValue(value: unknown): string {
  * which is personal data and must not be logged. Every `_`-separated segment that
  * looks like a snowflake is replaced with `<id>`, so the *shape* of the interaction
  * stays greppable while the identity does not survive.
+ *
+ * The guided raid-create flow (`events/raidCreateFlow.ts`) uses `handler:<draftId>`
+ * instead. The draft id is not personal data, but it is unique per flow, so leaving
+ * it in would give every line a distinct name and make drop-off rates impossible to
+ * count. Everything after the first `:` is therefore masked as well — the point of
+ * the log is which *step* people abandon, not which draft.
  */
 export function sanitizeCustomId(customId: unknown): string {
   if (customId === null || customId === undefined) return '-';
   const raw = String(customId).replace(UNSAFE_VALUE, '-');
   if (raw.length === 0) return '-';
 
-  const masked = raw
+  const [handler, ...payload] = raw.split(':');
+
+  const masked = handler
     .split('_')
     .map((segment) => (SNOWFLAKE.test(segment) ? '<id>' : segment))
     .join('_');
 
-  return clamp(masked);
+  return clamp(payload.length > 0 ? `${masked}:<id>` : masked);
 }
 
 /** Extract a stable, non-personal error class name. Never throws. */


### PR DESCRIPTION
Closes #38.

> [!IMPORTANT]
> **Gestapelt auf #40 (Issue #37).** Base-Branch ist `feat/37-iana-timezones`, nicht `main` — die Preview braucht die IANA-Zonen. Bitte **#40 zuerst mergen**; GitHub stellt diesen PR danach automatisch auf `main` um. Der Diff hier zeigt nur die #38-Änderungen.
>
> Ich habe gestapelt statt zu warten, weil #40 noch offen ist. Die Reihenfolge bleibt dadurch erzwungen — sag Bescheid, wenn du lieber sequenziell willst, dann rebase ich.

## Das Problem

Vier Freitext-Pflichtparameter in einer Zeile, keine Choices, keine nativen Option-Typen, Validierung erst zur Laufzeit. Genau davor stehen **88 von 108 Gilden**, die nie einen Raid angelegt haben.

## Der neue Weg

`/raid create` ohne Parameter → Modal (Name, Datum, Zeit) → Role-Select → Preview mit Bestätigung.

Rollen können **nicht** ins Modal (Discord-Modals sind reine Textfelder), deshalb der separate `RoleSelectMenuBuilder` als Follow-up — wie im Issue vorgezeichnet.

## Der alte Weg bleibt exakt erhalten

Alle vier Optionen sind jetzt `setRequired(false)`. Wer den Einzeiler im Kopf hat, merkt keinen Unterschied — bei vollständigen Parametern läuft unverändert der alte Pfad. Regressionstest ist drin.

Teilweise gefüllt ist jetzt **kein Fehler mehr, sondern der Einstieg**: `/raid create title:Mythic Prog` füllt das Modal vor, statt wie bisher hart abzubrechen. Leere Felder bekommen einen brauchbaren Default (nächstes 20:00 in der Gilden-Zone), damit man das Formular notfalls unverändert abschicken kann.

## Preview — hier zahlt #37 ein

`<t:unix:F>` rendert in der **eigenen** Discord-Zeit des Betrachters. Stimmt die Gilden-Zone nicht, sieht der Raidlead das **sofort** statt drei Tage später. `[Zeit korrigieren]` speichert die korrigierte Zone persistent auf der Gilde — eine Korrektur repariert alle künftigen Raids. Das ist Punkt 4 aus #37, hier umgesetzt wie abgesprochen.

## Zwei Design-Entscheidungen, die ich begründen sollte

**1. Permission-Check vor `deferReply()`.** `showModal()` muss die *erste* Antwort auf eine Interaction sein und kann keinem Defer folgen. Beide Zweige können sich also keinen deferred reply teilen. Folge: die Ablehnung ist jetzt ein ephemeres `reply` statt `editReply` — vier bestehende Tests entsprechend angepasst, die Ephemeralität ist weiterhin abgesichert.

**2. Drafts im Speicher, nicht in der DB.** Ein Draft ist wertlos, sobald das Interaction-Token abläuft (15 Min). Eine Tabelle dafür hieße Migration + Cleanup-Job für Zeilen, die nie wieder gelesen werden. Trade-off: Drafts überleben keinen Bot-Neustart — der Nutzer sieht dann „session expired" und ruft den Command neu auf. Setzt einen einzelnen Bot-Prozess voraus, was dem Deployment entspricht.

## Sauberkeit der Interaktionen

- Drafts sind an ihren Autor gebunden (Custom-IDs sind für jeden lesbar, der die Nachricht sieht)
- Draft wird **vor** dem Schreiben verbraucht → Doppelklick erzeugt keine zwei Raids
- Permissions werden beim Bestätigen erneut geprüft, nicht nur beim Command
- Abgelaufene Drafts räumen ihre Komponenten ab statt hängen zu bleiben
- Raid-Zeit, die zwischen Preview und Klick in die Vergangenheit rutscht, wird abgefangen

## Logging (Akzeptanzkriterium)

Role-Selects laufen jetzt durch denselben Logging-Zweig wie BTN/MODAL/SELECT. Custom-IDs haben die Form `handler:<draftId>` — `sanitizeCustomId()` maskiert die Draft-ID, sonst wäre jede Zeile unique und „wo brechen Leute ab" nicht zählbar. Jetzt aggregiert es pro Schritt.

## Struktur

Der Erzeugungs-Teil ist als `createRaidWithRoster()` extrahiert und wird von beiden Wegen benutzt — sie können nicht auseinanderlaufen.

## Tests

1044 → **1075 grün**, 0 rot, `tsc` sauber. 27 neue Tests in `src/events/__tests__/raidCreateFlow.test.ts`, entlang der Akzeptanzkriterien: Modal-Felder, Vorbefüllung, Role-Select, Preview mit `:F` **und** `:R`, DST-korrekte Umrechnung im Preview, Zonen-Persistierung, abgelaufene/fremde Drafts, Doppelklick, Timeouts.

## Deploy

**Nicht deployen ohne Freigabe.** Nach dem Merge müssen die Slash-Commands neu registriert werden (`npm run deploy:commands`), weil sich die Option-Pflichtfelder geändert haben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)