### PR TITLE
feat(premium): extend the trial to 30 days and move the running ones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ limits, and Discord/Stripe-agnostic subscription sync.
 - [x] **1.5 — Reusable upsell embed + free-tier hint**
   - `premiumUpsellEmbed(feature, currentTier, requiredTier, language)` — polished, localized rich embed showing the feature, current plan, and required plan
   - `premiumFooterHint(language)` — subtle `-#` subtext nudge, wired into gated command responses consistently
-- [x] **1.6 — 14-day Premium trial** — auto-granted on `guildCreate` (`grantTrialIfEligible()`); idempotent across re-installs, never clobbers an active subscription; surfaced in the welcome embed
+- [x] **1.6 — Premium trial** (14 days at launch, 30 since 2026-08-03) — auto-granted on `guildCreate` (`grantTrialIfEligible()`); idempotent across re-installs, never clobbers an active subscription; surfaced in the welcome embed
 
 ## Phase 2: Enhanced Raid Management
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "version:major": "npm version major --no-git-tag-version",
     "postinstall": "prisma generate",
     "e2e:test": "tsx scripts/e2e-test.ts",
-    "backfill:trials": "tsx src/scripts/backfillTrials.ts"
+    "backfill:trials": "tsx src/scripts/backfillTrials.ts",
+    "trials:extend": "tsx src/scripts/extendTrials.ts"
   },
   "keywords": [
     "discord",

--- a/src/__tests__/entitlementService.test.ts
+++ b/src/__tests__/entitlementService.test.ts
@@ -225,7 +225,7 @@ describe('tryConsumeWeeklyRaid()', () => {
 });
 
 describe('grantTrialIfEligible()', () => {
-  it('grants a 14-day PREMIUM trial via a single atomic conditional update', async () => {
+  it('grants a TRIAL_DAYS-long PREMIUM trial via a single atomic conditional update', async () => {
     // Eligibility lives in the WHERE clause; the DB reports one row was updated.
     (prisma.guild.updateMany as jest.Mock).mockResolvedValue({ count: 1 } as any);
 
@@ -251,7 +251,7 @@ describe('grantTrialIfEligible()', () => {
     expect(update.data.premiumTier).toBe('PREMIUM');
     expect(update.data.trialStartedAt).toBeInstanceOf(Date);
 
-    // Expiry is ~14 days out.
+    // Expiry is ~TRIAL_DAYS out.
     const expiryMs = (update.data.premiumExpiresAt as Date).getTime();
     const expectedMin = before + TRIAL_DAYS * 24 * 60 * 60 * 1000;
     const expectedMax = after + TRIAL_DAYS * 24 * 60 * 60 * 1000;

--- a/src/__tests__/extendTrials.test.ts
+++ b/src/__tests__/extendTrials.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the one-off trial-extension script (TRIAL_DAYS 14 -> 30).
+ *
+ * The script rewrites production rows by hand, so the properties that matter are
+ * safety ones: dry-run by default, a narrow target group, and idempotency.
+ */
+jest.mock('../database/client');
+
+import prisma from '../database/client';
+import { extendTrials } from '../scripts/extendTrials';
+import { TRIAL_DAYS } from '../services/entitlementService';
+
+const guildMock = (prisma as any).guild;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-08-03T12:00:00Z');
+
+/** A trial that started `daysAgo` days before NOW, still on the old 14-day expiry. */
+function legacyTrial(id: string, daysAgo: number) {
+  const trialStartedAt = new Date(NOW.getTime() - daysAgo * DAY_MS);
+  return {
+    id,
+    name: `Guild ${id}`,
+    trialStartedAt,
+    premiumExpiresAt: new Date(trialStartedAt.getTime() + 14 * DAY_MS),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  guildMock.updateMany.mockResolvedValue({ count: 1 });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('target group', () => {
+  it('selects only real trials without a paid entitlement', async () => {
+    guildMock.findMany.mockResolvedValue([]);
+
+    await extendTrials({ now: NOW });
+
+    expect(guildMock.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { trialStartedAt: { not: null }, entitlementId: null },
+      }),
+    );
+  });
+
+  it('never writes to a guild that has an entitlement', async () => {
+    // The paying guild is excluded by the query itself, so the script only ever sees
+    // trials. This asserts the predicate the database is given, which is the only
+    // thing standing between the one paying guild and a rewritten expiry.
+    guildMock.findMany.mockResolvedValue([]);
+
+    await extendTrials({ dryRun: false, now: NOW });
+
+    const where = guildMock.findMany.mock.calls[0][0].where;
+    expect(where.entitlementId).toBeNull();
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('re-asserts the predicate on every write, in case a guild starts paying mid-run', async () => {
+    guildMock.findMany.mockResolvedValue([legacyTrial('g1', 5)]);
+
+    await extendTrials({ dryRun: false, now: NOW });
+
+    expect(guildMock.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'g1', trialStartedAt: { not: null }, entitlementId: null },
+      }),
+    );
+  });
+});
+
+describe('dry run is the default', () => {
+  it('writes nothing when called with no options', async () => {
+    guildMock.findMany.mockResolvedValue([legacyTrial('g1', 5), legacyTrial('g2', 9)]);
+
+    const result = await extendTrials({ now: NOW });
+
+    expect(result.dryRun).toBe(true);
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('reports how many guilds are affected and how each expiry moves', async () => {
+    const trial = legacyTrial('g1', 5);
+    guildMock.findMany.mockResolvedValue([trial]);
+
+    const result = await extendTrials({ now: NOW });
+
+    expect(result.scanned).toBe(1);
+    expect(result.changed).toBe(1);
+    expect(result.plans[0].from).toEqual(trial.premiumExpiresAt);
+    expect(result.plans[0].to).toEqual(
+      new Date(trial.trialStartedAt.getTime() + TRIAL_DAYS * DAY_MS),
+    );
+  });
+
+  it('writes only when dryRun is explicitly false', async () => {
+    guildMock.findMany.mockResolvedValue([legacyTrial('g1', 5)]);
+
+    const result = await extendTrials({ dryRun: false, now: NOW });
+
+    expect(result.dryRun).toBe(false);
+    expect(guildMock.updateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('expiry maths', () => {
+  it('extends a running trial to exactly trialStartedAt + TRIAL_DAYS', async () => {
+    const trial = legacyTrial('g1', 6); // started 2026-07-28, expiring 2026-08-11
+    guildMock.findMany.mockResolvedValue([trial]);
+
+    await extendTrials({ dryRun: false, now: NOW });
+
+    expect(guildMock.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { premiumExpiresAt: new Date(trial.trialStartedAt.getTime() + 30 * DAY_MS) },
+      }),
+    );
+  });
+
+  it('computes from trialStartedAt, not from the current expiry', async () => {
+    // Same start date, wildly different current expiry: the result must not move.
+    const start = new Date('2026-07-20T10:00:00Z');
+    guildMock.findMany.mockResolvedValue([
+      { id: 'g1', name: 'A', trialStartedAt: start, premiumExpiresAt: new Date('2026-08-03T10:00:00Z') },
+      { id: 'g2', name: 'B', trialStartedAt: start, premiumExpiresAt: new Date('2027-01-01T00:00:00Z') },
+    ]);
+
+    const result = await extendTrials({ now: NOW });
+
+    const expected = new Date(start.getTime() + TRIAL_DAYS * DAY_MS);
+    expect(result.plans.map((p) => p.to)).toEqual([expected, expected]);
+  });
+
+  it('handles a trial whose expiry was never stamped', async () => {
+    const start = new Date('2026-07-20T10:00:00Z');
+    guildMock.findMany.mockResolvedValue([
+      { id: 'g1', name: 'A', trialStartedAt: start, premiumExpiresAt: null },
+    ]);
+
+    const result = await extendTrials({ now: NOW });
+
+    expect(result.changed).toBe(1);
+    expect(result.plans[0].from).toBeNull();
+    expect(result.plans[0].alreadyExpired).toBe(false);
+  });
+});
+
+describe('idempotency', () => {
+  it('reports a guild already on the new expiry as unchanged and does not write it', async () => {
+    const start = new Date('2026-07-20T10:00:00Z');
+    guildMock.findMany.mockResolvedValue([
+      {
+        id: 'g1',
+        name: 'A',
+        trialStartedAt: start,
+        premiumExpiresAt: new Date(start.getTime() + TRIAL_DAYS * DAY_MS),
+      },
+    ]);
+
+    const result = await extendTrials({ dryRun: false, now: NOW });
+
+    expect(result).toMatchObject({ scanned: 1, changed: 0, unchanged: 1 });
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on a second run against the rows the first run produced', async () => {
+    const trial = legacyTrial('g1', 6);
+    guildMock.findMany.mockResolvedValue([trial]);
+
+    const first = await extendTrials({ dryRun: false, now: NOW });
+    expect(first.changed).toBe(1);
+
+    // Feed back what the first run wrote.
+    guildMock.findMany.mockResolvedValue([
+      { ...trial, premiumExpiresAt: first.plans[0].to },
+    ]);
+    guildMock.updateMany.mockClear();
+
+    const second = await extendTrials({ dryRun: false, now: NOW });
+
+    expect(second).toMatchObject({ changed: 0, unchanged: 1 });
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('already-expired trials', () => {
+  it('revives a trial that expired but is still inside the new 30-day window', async () => {
+    // Started 20 days ago: the 14-day expiry passed 6 days ago, the 30-day one is
+    // 10 days out. This guild gets its remaining days back — that is the decision.
+    const trial = legacyTrial('g1', 20);
+    guildMock.findMany.mockResolvedValue([trial]);
+
+    const result = await extendTrials({ now: NOW });
+
+    expect(result.expired).toBe(1);
+    expect(result.plans[0].alreadyExpired).toBe(true);
+    expect(result.plans[0].to.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it('does not resurrect a trial that started more than TRIAL_DAYS ago', async () => {
+    // Started 60 days ago: recomputing lands 30 days in the past, so the guild stays
+    // expired. Included in the count, harmless in effect.
+    const trial = legacyTrial('g1', 60);
+    guildMock.findMany.mockResolvedValue([trial]);
+
+    const result = await extendTrials({ now: NOW });
+
+    expect(result.plans[0].to.getTime()).toBeLessThan(NOW.getTime());
+  });
+});
+
+describe('write failures', () => {
+  it('warns instead of throwing when a row no longer matches at write time', async () => {
+    guildMock.findMany.mockResolvedValue([legacyTrial('g1', 5)]);
+    guildMock.updateMany.mockResolvedValue({ count: 0 });
+    const warn = jest.spyOn(console, 'warn');
+
+    await expect(extendTrials({ dryRun: false, now: NOW })).resolves.toBeDefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('g1'));
+  });
+});

--- a/src/__tests__/welcomeEmbed.test.ts
+++ b/src/__tests__/welcomeEmbed.test.ts
@@ -2,6 +2,7 @@ jest.mock('../database/client');
 
 import { buildWelcomeEmbed } from '../utils/welcomeEmbed';
 import { t } from '../utils/localization';
+import { TRIAL_DAYS } from '../services/entitlementService';
 
 function trialField(embed: ReturnType<typeof buildWelcomeEmbed>) {
   return embed.toJSON().fields?.find((f) => f.name.includes('Premium Trial'));
@@ -36,8 +37,8 @@ describe('buildWelcomeEmbed()', () => {
     const deValue = trialField(de)?.value;
 
     // German locale must render the German trial copy, English the English copy.
-    expect(deValue).toContain(t('de', 'premiumTrialGranted', { tier: t('de', 'premiumTierPremium') }));
-    expect(enValue).toContain(t('en', 'premiumTrialGranted', { tier: t('en', 'premiumTierPremium') }));
+    expect(deValue).toContain(t('de', 'premiumTrialGranted', { days: String(TRIAL_DAYS), tier: t('de', 'premiumTierPremium') }));
+    expect(enValue).toContain(t('en', 'premiumTrialGranted', { days: String(TRIAL_DAYS), tier: t('en', 'premiumTierPremium') }));
 
     // Guard against a regression back to the hardcoded 'en' string.
     expect(deValue).not.toBe(enValue);

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ client.on(Events.GuildCreate, async (guild) => {
     console.error(`❌ Failed to ensure default team for ${guild.name}:`, error);
   }
 
-  // Auto-grant a one-time 14-day Premium trial to brand-new servers.
+  // Auto-grant a one-time Premium trial (TRIAL_DAYS) to brand-new servers.
   let trialGranted = false;
   try {
     const trial = await grantTrialIfEligible(guild.id);

--- a/src/scripts/backfillTrials.ts
+++ b/src/scripts/backfillTrials.ts
@@ -1,5 +1,5 @@
 /**
- * One-off backfill that starts the 14-day Premium trial for guilds that predate it.
+ * One-off backfill that starts the Premium trial for guilds that predate it.
  *
  * WHY THIS EXISTS: `grantTrialIfEligible()` was only ever wired into the `guildCreate`
  * event handler, and only since v0.5.0. Every guild that installed the bot before that

--- a/src/scripts/extendTrials.ts
+++ b/src/scripts/extendTrials.ts
@@ -1,0 +1,179 @@
+/**
+ * One-off data correction: moves running Premium trials onto the new TRIAL_DAYS length.
+ *
+ * WHY THIS EXISTS: `grantTrialIfEligible()` stamps `premiumExpiresAt` once, at grant
+ * time, and only ever fires for guilds with `trialStartedAt = null`. Raising
+ * `TRIAL_DAYS` from 14 to 30 therefore does nothing for the ~107 trials already
+ * running — they keep the expiry that was written when they started. This script
+ * rewrites those expiries.
+ *
+ * WHY IT IS NOT A MIGRATION: no schema changes, and it must not run automatically on
+ * deploy. It is a deliberate, reviewed correction of production rows, executed by hand
+ * after sign-off.
+ *
+ * WHY IT IS IDEMPOTENT: the new expiry is computed from `trialStartedAt`, never from
+ * the current `premiumExpiresAt`. Running it twice recomputes the same instant, so the
+ * second run reports zero changes instead of granting another 30 days.
+ *
+ * Usage (dry-run is the default — nothing is written without --apply):
+ *   npm run trials:extend
+ *   npm run trials:extend -- --apply
+ */
+import prisma from '../database/client';
+import { TRIAL_DAYS } from '../services/entitlementService';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface TrialExtensionPlan {
+  guildId: string;
+  guildName: string;
+  trialStartedAt: Date;
+  from: Date | null;
+  to: Date;
+  /** True when this trial's *current* expiry is already in the past. */
+  alreadyExpired: boolean;
+}
+
+export interface ExtendTrialsResult {
+  /** Guilds matching the target predicate (real trials, no paid entitlement). */
+  scanned: number;
+  /** Guilds whose expiry differs from the recomputed one. */
+  changed: number;
+  /** Guilds already sitting on the correct expiry — the idempotent case. */
+  unchanged: number;
+  /** Subset of `changed` whose current expiry is already in the past. */
+  expired: number;
+  /** True when nothing was written. */
+  dryRun: boolean;
+  plans: TrialExtensionPlan[];
+}
+
+/**
+ * Recomputes `premiumExpiresAt` as `trialStartedAt + TRIAL_DAYS` for every running trial.
+ *
+ * Target group, deliberately narrow:
+ *   - `trialStartedAt != null` — the guild is on a trial at all.
+ *   - `entitlementId = null` — never touch a paying guild. A paid subscription's expiry
+ *     is owned by the entitlement sync; rewriting it from a trial start date would
+ *     corrupt it. RaidPresence currently has exactly one such guild.
+ *
+ * Guilds whose trial has ALREADY EXPIRED are included on purpose. The decision: a guild
+ * that started a trial 20 days ago was promised the trial length the product now
+ * advertises, and 30 days from its start is still in the future, so it gets those days
+ * back. A trial that started more than 30 days ago recomputes to a past expiry —
+ * unchanged in effect, still expired, no resurrection. Either way the result is a pure
+ * function of `trialStartedAt`, which is what keeps the script idempotent. As of
+ * 2026-08-03 no trial has expired yet, but the script does not assume that.
+ *
+ * @param options.dryRun Defaults to true. Nothing is written unless this is explicitly false.
+ */
+export async function extendTrials(
+  options: { dryRun?: boolean; now?: Date } = {},
+): Promise<ExtendTrialsResult> {
+  const dryRun = options.dryRun ?? true;
+  const now = options.now ?? new Date();
+
+  const candidates = await prisma.guild.findMany({
+    where: {
+      trialStartedAt: { not: null },
+      entitlementId: null,
+    },
+    select: {
+      id: true,
+      name: true,
+      trialStartedAt: true,
+      premiumExpiresAt: true,
+    },
+  });
+
+  const plans: TrialExtensionPlan[] = [];
+  let unchanged = 0;
+
+  for (const guild of candidates) {
+    // Narrowing only — the WHERE clause already excludes nulls.
+    if (!guild.trialStartedAt) continue;
+
+    const to = new Date(guild.trialStartedAt.getTime() + TRIAL_DAYS * DAY_MS);
+    const from = guild.premiumExpiresAt;
+
+    if (from && from.getTime() === to.getTime()) {
+      unchanged++;
+      continue;
+    }
+
+    plans.push({
+      guildId: guild.id,
+      guildName: guild.name,
+      trialStartedAt: guild.trialStartedAt,
+      from,
+      to,
+      alreadyExpired: from !== null && from < now,
+    });
+  }
+
+  const expired = plans.filter((p) => p.alreadyExpired).length;
+
+  console.log(
+    `🎁 Trial extension (${TRIAL_DAYS}d): scanned=${candidates.length} ` +
+      `changed=${plans.length} unchanged=${unchanged} alreadyExpired=${expired} dryRun=${dryRun}`,
+  );
+
+  for (const plan of plans) {
+    console.log(
+      `   ${plan.guildId} (${plan.guildName}): ` +
+        `${plan.from ? plan.from.toISOString() : 'none'} -> ${plan.to.toISOString()}` +
+        `${plan.alreadyExpired ? ' [was already expired]' : ''}`,
+    );
+  }
+
+  if (dryRun) {
+    console.log('🔍 Dry run — no rows were written. Re-run with --apply to persist.');
+    return {
+      scanned: candidates.length,
+      changed: plans.length,
+      unchanged,
+      expired,
+      dryRun: true,
+      plans,
+    };
+  }
+
+  for (const plan of plans) {
+    // One update per guild rather than a bulk statement: each row gets a different
+    // expiry, and a single failure must not take the rest of the batch with it. The
+    // WHERE clause re-asserts the target predicate so a guild that started paying
+    // between the scan and the write is skipped by the database, not just by us.
+    const { count } = await prisma.guild.updateMany({
+      where: { id: plan.guildId, trialStartedAt: { not: null }, entitlementId: null },
+      data: { premiumExpiresAt: plan.to },
+    });
+
+    if (count === 0) {
+      console.warn(`⚠️ Skipped ${plan.guildId}: no longer an eligible trial at write time`);
+    }
+  }
+
+  console.log(`✅ Trial extension applied to ${plans.length} guild(s).`);
+
+  return {
+    scanned: candidates.length,
+    changed: plans.length,
+    unchanged,
+    expired,
+    dryRun: false,
+    plans,
+  };
+}
+
+if (require.main === module) {
+  // Default to a dry run: this runs against production by hand, and the safe mode has
+  // to be the one you get when you forget a flag.
+  const apply = process.argv.includes('--apply');
+
+  extendTrials({ dryRun: !apply })
+    .catch((error) => {
+      console.error('❌ Trial extension aborted:', error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/src/services/entitlementService.ts
+++ b/src/services/entitlementService.ts
@@ -214,8 +214,15 @@ export async function tryConsumeWeeklyRaid(guildId: string): Promise<{ allowed: 
   });
 }
 
-/** Length of the auto-granted new-guild premium trial, in days. */
-export const TRIAL_DAYS = 14;
+/**
+ * Length of the auto-granted new-guild premium trial, in days.
+ *
+ * Raised from 14 to 30 on 2026-08-03: two weeks is not enough to see a raid cycle
+ * through on a server that only runs one or two nights a week. Changing this only
+ * affects guilds granted a trial *after* the change — `premiumExpiresAt` is stamped
+ * once at grant time. Trials already running are moved by `src/scripts/extendTrials.ts`.
+ */
+export const TRIAL_DAYS = 30;
 
 export interface TrialGrantResult {
   granted: boolean;
@@ -224,7 +231,7 @@ export interface TrialGrantResult {
 }
 
 /**
- * Grants a one-time 14-day PREMIUM trial to a guild, if eligible.
+ * Grants a one-time {@link TRIAL_DAYS}-day PREMIUM trial to a guild, if eligible.
  *
  * Eligible only when the guild has never had a trial (`trialStartedAt` is null),
  * is currently on FREE, and has no linked paid entitlement. This keeps the grant

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -498,7 +498,7 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumFooterHint: '-# 💎 Upgrade to Premium for multiple teams, archives, analytics & unlimited raids.',
 
         // Premium trial (Phase 1.6)
-        premiumTrialGranted: '🎁 **Your 14-day {tier} trial is active!** Enjoy unlimited raids, archives and analytics — no card required. It ends automatically, nothing to cancel.',
+        premiumTrialGranted: '🎁 **Your {days}-day {tier} trial is active!** Enjoy unlimited raids, archives and analytics — no card required. It ends automatically, nothing to cancel.',
         premiumTrialTeamsHint: 'During your trial you can create as many teams as you like.',
 
         // Premium feature display names (localized upsell embed)
@@ -755,7 +755,7 @@ const translations: Record<SupportedLanguage, Translations> = {
         premiumFooterHint: '-# 💎 Upgrade auf Premium für mehrere Teams, Archive, Analysen & unbegrenzte Raids.',
 
         // Premium trial (Phase 1.6)
-        premiumTrialGranted: '🎁 **Deine 14-tägige {tier}-Testphase ist aktiv!** Genieße unbegrenzte Raids, Archive und Analysen – ohne Kreditkarte. Sie endet automatisch, nichts zu kündigen.',
+        premiumTrialGranted: '🎁 **Deine {days}-tägige {tier}-Testphase ist aktiv!** Genieße unbegrenzte Raids, Archive und Analysen – ohne Kreditkarte. Sie endet automatisch, nichts zu kündigen.',
         premiumTrialTeamsHint: 'Während der Testphase kannst du beliebig viele Teams anlegen.',
 
         // Premium feature display names (localized upsell embed)

--- a/src/utils/welcomeEmbed.ts
+++ b/src/utils/welcomeEmbed.ts
@@ -91,7 +91,10 @@ export function buildWelcomeEmbed(params: WelcomeEmbedParams): EmbedBuilder {
   if (trialGranted) {
     welcomeEmbed.addFields({
       name: `🎁 ${TRIAL_DAYS}-Day Premium Trial`,
-      value: t(language, 'premiumTrialGranted', { tier: t(language, 'premiumTierPremium') }) +
+      value: t(language, 'premiumTrialGranted', {
+        days: String(TRIAL_DAYS),
+        tier: t(language, 'premiumTierPremium'),
+      }) +
              `\n${t(language, 'premiumTrialTeamsHint')}`,
       inline: false,
     });


### PR DESCRIPTION
Trial length goes from 14 to 30 days. Two parts, because the constant alone does not reach anyone who is already on a trial.

## 1. `TRIAL_DAYS = 30`

`grantTrialIfEligible()` stamps `premiumExpiresAt` once, at grant time, and only fires when `trialStartedAt` is null. Raising the constant therefore only affects guilds that get a trial *after* this ships.

## 2. `src/scripts/extendTrials.ts` — for the ~107 trials already running

They currently expire on 2026-08-11. The script recomputes `premiumExpiresAt` as `trialStartedAt + TRIAL_DAYS`.

- **Not a Prisma migration.** No schema change, and it must not run on deploy. It is a manual, reviewed data correction.
- **Dry-run by default.** `npm run trials:extend` prints the affected guild count and every `from -> to` move, and writes nothing. Only `npm run trials:extend -- --apply` persists.
- **Narrow target group:** `trialStartedAt != null AND entitlementId = null`. The one guild with a real entitlement is excluded by the query, and the predicate is re-asserted in the `WHERE` of every write in case a guild starts paying mid-run.
- **Idempotent.** The new expiry is a pure function of `trialStartedAt`, never of the current `premiumExpiresAt`, so a second run reports `changed=0`.

### Decision on already-expired trials

They are **included**. A guild that started its trial 20 days ago was promised the length the product now advertises, and `start + 30d` is still in the future, so it gets those days back. A trial that started more than 30 days ago recomputes to a date in the past — it stays expired, no resurrection. As of 2026-08-03 nothing has expired yet, but the script does not assume that; both cases are tested.

## Also

User-facing trial copy (en + de) now interpolates `TRIAL_DAYS` instead of hardcoding "14".

## Verification

`npm run test` (tsc) and the full Jest suite pass: 987 passed, 2 skipped. 14 new tests cover the target group, dry-run default, expiry maths, idempotency across two runs, and the expired-trial cases.

**Nothing has been run against production.** The script waits for your go-ahead.