### PR TITLE
docs(trials): note that trials:extend needs a clean entitlement sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ npm run db:migrate:deploy
 npm run deploy:commands
 ```
 
+### Extending Running Trials
+
+One-off data correction that moves already-running Premium trials onto the current
+`TRIAL_DAYS` length. Dry-run is the default; nothing is written without `--apply`.
+
+```bash
+npm run trials:extend            # dry run — prints the plan, writes nothing
+npm run trials:extend -- --apply # writes the recomputed expiries
+```
+
+**Run it after a clean entitlement sync, in a quiet window.** The script skips paying
+guilds via `entitlementId = null`, and re-asserts that predicate in the WHERE clause of
+every write — but that check can only see what the entitlement sync has already written
+to the database. A guild whose payment lands at Discord *during* the run, before the sync
+has stamped its `entitlementId` locally, still looks like a plain trial to both the scan
+and the write. The window is small and the damage is limited to one overwritten
+`premiumExpiresAt`, which the next entitlement sync corrects — but waiting for a clean
+sync and picking a low-traffic window removes it. The script is idempotent (expiry is
+recomputed from `trialStartedAt`), so a re-run after the sync is always safe.
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/src/scripts/extendTrials.ts
+++ b/src/scripts/extendTrials.ts
@@ -15,6 +15,11 @@
  * the current `premiumExpiresAt`. Running it twice recomputes the same instant, so the
  * second run reports zero changes instead of granting another 30 days.
  *
+ * WHEN TO RUN IT: after a clean entitlement sync, in a quiet window. The paying-guild
+ * guard below can only see entitlements the sync has already written locally, so a
+ * payment that lands at Discord mid-run is not covered by it — see the note on the
+ * updateMany WHERE clause. Waiting for a clean sync closes that window.
+ *
  * Usage (dry-run is the default — nothing is written without --apply):
  *   npm run trials:extend
  *   npm run trials:extend -- --apply
@@ -143,6 +148,11 @@ export async function extendTrials(
     // expiry, and a single failure must not take the rest of the batch with it. The
     // WHERE clause re-asserts the target predicate so a guild that started paying
     // between the scan and the write is skipped by the database, not just by us.
+    // Note the limit of that guarantee: it holds against the *local* entitlement row,
+    // i.e. once the sync has written `entitlementId` — not against the external payment
+    // event that precedes it. A guild that pays at Discord mid-run still reads as a
+    // trial here until the sync catches up. Hence the runbook rule: run this after a
+    // clean entitlement sync, in a quiet window.
     const { count } = await prisma.guild.updateMany({
       where: { id: plan.guildId, trialStartedAt: { not: null }, entitlementId: null },
       data: { premiumExpiresAt: plan.to },


### PR DESCRIPTION
Follow-up to the SHOULD-point Codex left on #43. No code change — documentation only.

## The point

`extendTrials` skips paying guilds with `entitlementId: null`, and re-asserts that predicate in the `updateMany` WHERE clause of every write. The inline comment claimed this covers "a guild that started paying between the scan and the write."

That holds against the **local** entitlement row — i.e. once the entitlement sync has written `entitlementId`. It does **not** hold against the external payment event that precedes that write. A guild whose payment lands at Discord mid-run still reads as a plain trial to both the scan and the write.

## Why this is a note and not a fix

The exposure is one overwritten `premiumExpiresAt`, which the next entitlement sync corrects, and the script is idempotent (expiry is recomputed from `trialStartedAt`, never from the current expiry). Closing the window properly would mean coordinating with the sync — not worth it for a one-off correction that an operator runs by hand after sign-off. Sequencing the run is the cheaper control.

## Changes

- `src/scripts/extendTrials.ts` — a `WHEN TO RUN IT` paragraph in the header, and a correction at the WHERE-clause comment that overstated the guarantee.
- `README.md` — an "Extending Running Trials" runbook section under Usage, with the dry-run/apply invocations and the rule: run after a clean entitlement sync, in a quiet window.

## Verification

- `npm run test` (tsc --noEmit) — passes
- `npx jest` — 1101 passed, 0 failed, 2 skipped