### PR TITLE
test(timezone): stop asserting Node 20+ Intl behaviour

### DIFF
--- a/src/utils/__tests__/timezoneHelper.test.ts
+++ b/src/utils/__tests__/timezoneHelper.test.ts
@@ -50,11 +50,20 @@ describe('isValidTimezone()', () => {
     }
   );
 
-  // Node's Intl also accepts ES2022 offset identifiers such as '+01:00'. That is
-  // harmless — it is a real, unambiguous zone, just one without DST rules — so it is
-  // deliberately not in the reject list below.
-  it('accepts an ES2022 offset identifier', () => {
-    expect(isValidTimezone('+01:00')).toBe(true);
+  // ES2022 offset identifiers such as '+01:00' are runtime-dependent: Node 20+ accepts
+  // them, Node 18 (what the Docker image and CI run) throws RangeError. isValidTimezone
+  // deliberately delegates that judgement to Intl rather than second-guessing it, so the
+  // contract under test is "agrees with Intl", not a fixed verdict. Either answer is
+  // correct — an offset identifier is a real zone without DST rules, and rejecting it on
+  // older runtimes only turns away an exotic input format nothing in the bot emits.
+  it('agrees with Intl on ES2022 offset identifiers', () => {
+    let intlAccepts = true;
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: '+01:00' });
+    } catch {
+      intlAccepts = false;
+    }
+    expect(isValidTimezone('+01:00')).toBe(intlAccepts);
   });
 
   it.each([


### PR DESCRIPTION
CI went red on the `v0.7.0` tag: `isValidTimezone('+01:00')` expected `true`, got `false`.

Not a code bug — a runtime difference. CI and the Docker image run **node:18-alpine**; the dev machine runs Node 22. ES2022 offset identifiers landed in Node 20.

Verified empirically on `node:18-alpine` that everything the migration actually emits is fine:

| Zone | Node 18 |
|---|---|
| `Etc/GMT-1` | GMT+01:00 ✅ |
| `Etc/GMT+5` | GMT−05:00 ✅ |
| `Etc/GMT-14` / `Etc/GMT+12` | ✅ |
| `Europe/Berlin`, `America/New_York` | ✅ |
| `+01:00` | RangeError |

So the sign inversion holds on the production runtime. Only the offset-identifier input form differs, and nothing in the bot emits it.

The test now asserts that `isValidTimezone` agrees with `Intl` rather than hardcoding one runtime's verdict. Green on Node 22 and node:18-alpine.