### PR TITLE
Welcome-Setup: Sprache und Leader-Rollen im ersten Durchgang mitfragen (#48)

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -110,6 +110,24 @@ const command: Command = {
   },
 };
 
+/**
+ * Renders `raidLeaderRoles` for `/config view`.
+ *
+ * The column holds names *or* IDs. Since #48 the welcome setup chain writes IDs
+ * (that is what a `RoleSelectMenu` yields), so a raw dump would show a row of
+ * meaningless numbers — snowflakes are rendered as role mentions instead, names
+ * stay in code ticks.
+ */
+export function formatLeaderRoles(raw: string | null): string {
+  const entries = cleanLeaderRoles(raw || '');
+  if (!entries) return '`Not configured (uses ManageEvents permission)`';
+
+  return entries
+    .split(',')
+    .map((entry) => (/^\d{17,20}$/.test(entry) ? `<@&${entry}>` : `\`${entry}\``))
+    .join(' ');
+}
+
 async function handleViewConfig(interaction: ChatInputCommandInteraction) {
   if (!interaction.guild) {
     await interaction.reply({
@@ -132,7 +150,7 @@ async function handleViewConfig(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  const leaderRoles = guildData.raidLeaderRoles || 'Not configured (uses ManageEvents permission)';
+  const leaderRoles = formatLeaderRoles(guildData.raidLeaderRoles);
   const language = guildData.language === 'de' ? 'Deutsch (German)' : 'English';
   const timezone = guildData.timezone || DEFAULT_TIMEZONE;
   const timezoneDisplay = formatTimezoneLabel(timezone);
@@ -145,7 +163,7 @@ async function handleViewConfig(interaction: ChatInputCommandInteraction) {
     .addFields(
       {
         name: 'Raid Leader Roles',
-        value: `\`${leaderRoles}\`\n\nMembers with these roles can create and delete raids.`,
+        value: `${leaderRoles}\n\nMembers with these roles can create and delete raids.`,
         inline: false,
       },
       {
@@ -176,6 +194,62 @@ async function handleViewConfig(interaction: ChatInputCommandInteraction) {
   await interaction.editReply({ embeds: [embed], content: hint || undefined });
 }
 
+/**
+ * Normalises the comma-separated `raidLeaderRoles` column value.
+ *
+ * Entries may be role IDs or role names — `canManageRaids` matches either — so this
+ * only trims and drops empties. Returns `''` when nothing usable is left, which the
+ * callers treat as "reject" rather than "clear".
+ */
+export function cleanLeaderRoles(input: string): string {
+  return input
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .join(',');
+}
+
+/**
+ * The single write path for `Guild.raidLeaderRoles`.
+ *
+ * Shared with the welcome setup chain (#48) so the column has exactly one writer;
+ * the welcome flow can be triggered from a DM, where the guild name is only
+ * available from the client cache, hence the explicit `guildName` parameter.
+ */
+export async function setLeaderRoles(
+  guildId: string,
+  guildName: string,
+  cleanedRoles: string
+): Promise<void> {
+  await prisma.guild.upsert({
+    where: { id: guildId },
+    update: { raidLeaderRoles: cleanedRoles },
+    create: {
+      id: guildId,
+      name: guildName,
+      raidLeaderRoles: cleanedRoles,
+    },
+  });
+}
+
+/** The single write path for `Guild.language`. Shared with the welcome chain (#48). */
+export async function setLanguage(
+  guildId: string,
+  guildName: string,
+  language: 'en' | 'de'
+): Promise<void> {
+  await prisma.guild.upsert({
+    where: { id: guildId },
+    update: { language },
+    create: {
+      id: guildId,
+      name: guildName,
+      raidLeaderRoles: '',
+      language,
+    },
+  });
+}
+
 async function handleSetLeaderRoles(interaction: ChatInputCommandInteraction) {
   if (!interaction.guild) {
     await interaction.reply({
@@ -188,13 +262,7 @@ async function handleSetLeaderRoles(interaction: ChatInputCommandInteraction) {
   await interaction.deferReply({ ephemeral: true });
 
   const roles = interaction.options.get('roles', true).value as string;
-
-  // Validate and clean up the roles string
-  const cleanedRoles = roles
-    .split(',')
-    .map((r) => r.trim())
-    .filter(Boolean)
-    .join(',');
+  const cleanedRoles = cleanLeaderRoles(roles);
 
   if (!cleanedRoles) {
     await interaction.editReply({
@@ -203,16 +271,7 @@ async function handleSetLeaderRoles(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  // Update in database
-  await prisma.guild.upsert({
-    where: { id: interaction.guild.id },
-    update: { raidLeaderRoles: cleanedRoles },
-    create: {
-      id: interaction.guild.id,
-      name: interaction.guild.name,
-      raidLeaderRoles: cleanedRoles,
-    },
-  });
+  await setLeaderRoles(interaction.guild.id, interaction.guild.name, cleanedRoles);
 
   await interaction.editReply({
     content: `✅ Raid leader roles updated to: \`${cleanedRoles}\`\n\nMembers with these roles can now create and manage raids.`,
@@ -239,17 +298,7 @@ async function handleSetLanguage(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  // Update in database
-  await prisma.guild.upsert({
-    where: { id: interaction.guild.id },
-    update: { language },
-    create: {
-      id: interaction.guild.id,
-      name: interaction.guild.name,
-      raidLeaderRoles: '',
-      language,
-    },
-  });
+  await setLanguage(interaction.guild.id, interaction.guild.name, language);
 
   const languageName = language === 'de' ? 'Deutsch (German)' : 'English';
   await interaction.editReply({

--- a/src/events/__tests__/welcomeFlow.test.ts
+++ b/src/events/__tests__/welcomeFlow.test.ts
@@ -16,18 +16,26 @@ import prisma from '../../database/client';
 import { canManageRaids } from '../../utils/permissions';
 import { startGuidedRaidCreate } from '../raidCreateFlow';
 import {
+  handleLanguageSelect,
+  handleLeaderRolesSelect,
   handleTimezoneSelect,
   isWelcomeButton,
+  isWelcomeRoleSelect,
   isWelcomeSelect,
   routeWelcomeButton,
 } from '../welcomeFlow';
 
 const GUILD_ID = '123456789012345678';
+const ROLE_ID = '987654321098765432';
+
+function guildCache() {
+  const guilds = new Map<string, any>();
+  guilds.set(GUILD_ID, { id: GUILD_ID, name: 'Test Guild' });
+  return { cache: guilds };
+}
 
 function buildButton(customId: string, opts: { inGuild?: boolean } = {}) {
   const inGuild = opts.inGuild ?? true;
-  const guilds = new Map<string, any>();
-  guilds.set(GUILD_ID, { id: GUILD_ID, name: 'Test Guild' });
 
   return {
     customId,
@@ -37,19 +45,34 @@ function buildButton(customId: string, opts: { inGuild?: boolean } = {}) {
     guildId: inGuild ? GUILD_ID : null,
     channel: inGuild ? { id: 'channel-1' } : null,
     member: inGuild ? {} : null,
-    client: { guilds: { cache: guilds } },
+    client: { guilds: guildCache() },
     reply: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
     showModal: jest.fn().mockResolvedValue(undefined),
   } as any;
 }
 
-function buildSelect(customId: string, values: string[]) {
+function buildSelect(customId: string, values: string[], opts: { inGuild?: boolean } = {}) {
+  const inGuild = opts.inGuild ?? true;
+
   return {
     customId,
     values,
     user: { id: 'user-1' },
+    guild: inGuild ? { id: GUILD_ID, name: 'Test Guild' } : null,
+    guildId: inGuild ? GUILD_ID : null,
+    client: { guilds: guildCache() },
     update: jest.fn().mockResolvedValue(undefined),
   } as any;
+}
+
+/** The component rows of the last `update()` / `reply()` on an interaction. */
+function rowsOf(call: any): any[] {
+  return (call.components ?? []).map((row: any) => row.toJSON());
+}
+
+function firstComponent(call: any): any {
+  return rowsOf(call)[0].components[0];
 }
 
 describe('welcome buttons', () => {
@@ -62,19 +85,24 @@ describe('welcome buttons', () => {
       timezone: 'UTC',
     });
     (prisma.guild.update as jest.Mock).mockResolvedValue({});
+    (prisma.guild.upsert as jest.Mock).mockResolvedValue({});
   });
 
   describe('dispatch predicates', () => {
     it('claims its own custom IDs', () => {
       expect(isWelcomeButton(`welcome-setup:${GUILD_ID}`)).toBe(true);
       expect(isWelcomeButton(`welcome-firstraid:${GUILD_ID}`)).toBe(true);
+      expect(isWelcomeButton(`welcome-skip:${GUILD_ID}:tz`)).toBe(true);
       expect(isWelcomeSelect(`welcome-tz:${GUILD_ID}`)).toBe(true);
+      expect(isWelcomeSelect(`welcome-lang:${GUILD_ID}`)).toBe(true);
+      expect(isWelcomeRoleSelect(`welcome-roles:${GUILD_ID}`)).toBe(true);
     });
 
     it('leaves the attendance and raid-create handlers alone', () => {
       expect(isWelcomeButton('raid_optin_raid1')).toBe(false);
       expect(isWelcomeButton('rcflow-confirm:d1')).toBe(false);
       expect(isWelcomeSelect('class_select_raid1')).toBe(false);
+      expect(isWelcomeRoleSelect('rcflow-roles:d1')).toBe(false);
     });
   });
 
@@ -139,19 +167,31 @@ describe('welcome buttons', () => {
     });
   });
 
-  describe('[Start setup]', () => {
-    it('asks only for the timezone — the one setting that must be right', async () => {
+  describe('[Start setup] — step 1, timezone', () => {
+    it('opens with the timezone picker and a skip button', async () => {
       const button = buildButton(`welcome-setup:${GUILD_ID}`);
 
       await routeWelcomeButton(button);
 
       const reply = button.reply.mock.calls[0][0];
       expect(reply.ephemeral).toBe(true);
-      const select = reply.components[0].toJSON().components[0];
+      const select = firstComponent(reply);
       expect(select.custom_id).toBe(`welcome-tz:${GUILD_ID}`);
       expect(select.options.length).toBeGreaterThan(0);
       // Discord's hard cap on select options.
       expect(select.options.length).toBeLessThanOrEqual(25);
+
+      // Every step is skippable — that is what keeps the chain non-blocking.
+      const skip = rowsOf(reply)[1].components[0];
+      expect(skip.custom_id).toBe(`welcome-skip:${GUILD_ID}:tz`);
+    });
+
+    it('announces itself as step 1 of 3', async () => {
+      const button = buildButton(`welcome-setup:${GUILD_ID}`);
+
+      await routeWelcomeButton(button);
+
+      expect(button.reply.mock.calls[0][0].content).toContain('Step 1 of 3');
     });
 
     // Setting a guild row needs no guild context, so this one works in a DM too.
@@ -165,16 +205,6 @@ describe('welcome buttons', () => {
       );
     });
 
-    it('mentions leader roles as optional rather than as a required step', async () => {
-      const button = buildButton(`welcome-setup:${GUILD_ID}`);
-
-      await routeWelcomeButton(button);
-
-      const content = button.reply.mock.calls[0][0].content;
-      expect(content).toContain('/config leader-roles');
-      expect(content).toContain('Optional');
-    });
-
     it('uses the guild language', async () => {
       (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
         id: GUILD_ID, language: 'de', timezone: 'UTC',
@@ -185,9 +215,7 @@ describe('welcome buttons', () => {
 
       expect(button.reply.mock.calls[0][0].content).toContain('Zeitzone');
     });
-  });
 
-  describe('timezone select', () => {
     it('persists the chosen zone on the guild', async () => {
       const select = buildSelect(`welcome-tz:${GUILD_ID}`, ['Europe/Berlin']);
 
@@ -201,14 +229,15 @@ describe('welcome buttons', () => {
       });
     });
 
-    it('confirms and clears the menu so the step cannot be repeated by accident', async () => {
+    it('confirms the zone and moves on to the language step', async () => {
       const select = buildSelect(`welcome-tz:${GUILD_ID}`, ['Europe/Berlin']);
 
       await handleTimezoneSelect(select);
 
       const update = select.update.mock.calls[0][0];
-      expect(update.components).toEqual([]);
       expect(update.content).toContain('Europe/Berlin');
+      expect(update.content).toContain('Step 2 of 3');
+      expect(firstComponent(update).custom_id).toBe(`welcome-lang:${GUILD_ID}`);
     });
 
     it('rejects an unrecognised zone without writing', async () => {
@@ -217,6 +246,172 @@ describe('welcome buttons', () => {
       await handleTimezoneSelect(select);
 
       expect(prisma.guild.update).not.toHaveBeenCalled();
+    });
+
+    it('skips to the language step without writing a timezone', async () => {
+      const button = buildButton(`welcome-skip:${GUILD_ID}:tz`);
+
+      await routeWelcomeButton(button);
+
+      expect(prisma.guild.update).not.toHaveBeenCalled();
+      const update = button.update.mock.calls[0][0];
+      expect(update.content).toContain('Step 2 of 3');
+      expect(firstComponent(update).custom_id).toBe(`welcome-lang:${GUILD_ID}`);
+    });
+  });
+
+  describe('step 2 — language', () => {
+    it('preselects the language guessed at guild-create time', async () => {
+      const select = buildSelect(`welcome-tz:${GUILD_ID}`, ['Europe/Berlin']);
+
+      await handleTimezoneSelect(select);
+
+      const options = firstComponent(select.update.mock.calls[0][0]).options;
+      expect(options.map((o: any) => o.value)).toEqual(['en', 'de']);
+      expect(options.find((o: any) => o.value === 'en').default).toBe(true);
+    });
+
+    it('writes the language through the /config upsert path', async () => {
+      const select = buildSelect(`welcome-lang:${GUILD_ID}`, ['de']);
+
+      await handleLanguageSelect(select);
+
+      expect(prisma.guild.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: GUILD_ID },
+          update: { language: 'de' },
+        })
+      );
+    });
+
+    // Acceptance criterion: the choice takes effect for the remaining steps, not
+    // only for the next raid message.
+    it('renders the following step in the language just chosen', async () => {
+      const select = buildSelect(`welcome-lang:${GUILD_ID}`, ['de']);
+
+      await handleLanguageSelect(select);
+
+      const content = select.update.mock.calls[0][0].content;
+      expect(content).toContain('Sprache auf **Deutsch** gesetzt');
+      expect(content).toContain('Schritt 3 von 3');
+      expect(content).not.toContain('Step 3 of 3');
+    });
+
+    it('skips to the leader-role step keeping the current language', async () => {
+      const button = buildButton(`welcome-skip:${GUILD_ID}:lang`);
+
+      await routeWelcomeButton(button);
+
+      expect(prisma.guild.upsert).not.toHaveBeenCalled();
+      const update = button.update.mock.calls[0][0];
+      expect(update.content).toContain('Step 3 of 3');
+      expect(firstComponent(update).custom_id).toBe(`welcome-roles:${GUILD_ID}`);
+    });
+  });
+
+  describe('step 3 — leader roles', () => {
+    it('offers a role select inside a guild', async () => {
+      const select = buildSelect(`welcome-lang:${GUILD_ID}`, ['en']);
+
+      await handleLanguageSelect(select);
+
+      const roleSelect = firstComponent(select.update.mock.calls[0][0]);
+      expect(roleSelect.custom_id).toBe(`welcome-roles:${GUILD_ID}`);
+      // Zero is allowed: an empty submit means "keep the default", same as [Skip].
+      expect(roleSelect.min_values).toBe(0);
+    });
+
+    // The DM fallstrick: a RoleSelectMenu has no guild to resolve roles against, so
+    // the chain has to end with a pointer instead of an empty menu.
+    it('points into the server instead of showing a role menu in a DM', async () => {
+      const select = buildSelect(`welcome-lang:${GUILD_ID}`, ['en'], { inGuild: false });
+
+      await handleLanguageSelect(select);
+
+      const update = select.update.mock.calls[0][0];
+      expect(update.components).toEqual([]);
+      expect(update.content).toContain('/config leader-roles');
+      expect(update.content).toContain('Test Guild');
+      expect(update.content).toContain(`https://discord.com/channels/${GUILD_ID}`);
+    });
+
+    // Same guard as [Create first raid]: a DM button could come from any server the
+    // user installed the bot into.
+    it('points into the server when pressed inside a different guild', async () => {
+      const select = buildSelect('welcome-lang:999999999999999999', ['en']);
+
+      await handleLanguageSelect(select);
+
+      const update = select.update.mock.calls[0][0];
+      expect(update.components).toEqual([]);
+      expect(update.content).toContain('/config leader-roles');
+    });
+
+    it('stores the picked roles as IDs through the /config upsert path', async () => {
+      const select = buildSelect(`welcome-roles:${GUILD_ID}`, [ROLE_ID]);
+
+      await handleLeaderRolesSelect(select);
+
+      expect(prisma.guild.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: GUILD_ID },
+          update: { raidLeaderRoles: ROLE_ID },
+        })
+      );
+    });
+
+    // Acceptance criterion: leaving it empty must behave exactly as before.
+    it('writes nothing when no role is picked', async () => {
+      const select = buildSelect(`welcome-roles:${GUILD_ID}`, []);
+
+      await handleLeaderRolesSelect(select);
+
+      expect(prisma.guild.upsert).not.toHaveBeenCalled();
+      expect(select.update.mock.calls[0][0].content).toContain('Manage Events');
+    });
+
+    it('writes nothing when the step is skipped', async () => {
+      const button = buildButton(`welcome-skip:${GUILD_ID}:roles`);
+
+      await routeWelcomeButton(button);
+
+      expect(prisma.guild.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('summary', () => {
+    it('closes the chain with the stored settings and points at /config view', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+        id: GUILD_ID,
+        language: 'en',
+        timezone: 'Europe/Berlin',
+        raidLeaderRoles: ROLE_ID,
+      });
+      const select = buildSelect(`welcome-roles:${GUILD_ID}`, [ROLE_ID]);
+
+      await handleLeaderRolesSelect(select);
+
+      const update = select.update.mock.calls[0][0];
+      expect(update.components).toEqual([]);
+      expect(update.content).toContain('Europe/Berlin');
+      expect(update.content).toContain('English');
+      expect(update.content).toContain(`<@&${ROLE_ID}>`);
+      expect(update.content).toContain('/config view');
+    });
+
+    // A skipped step must show what was already stored, not a blank.
+    it('reports the pre-existing timezone after a skipped first step', async () => {
+      (prisma.guild.findUnique as jest.Mock).mockResolvedValue({
+        id: GUILD_ID,
+        language: 'en',
+        timezone: 'America/New_York',
+        raidLeaderRoles: '',
+      });
+      const button = buildButton(`welcome-skip:${GUILD_ID}:roles`);
+
+      await routeWelcomeButton(button);
+
+      expect(button.update.mock.calls[0][0].content).toContain('America/New_York');
     });
   });
 });

--- a/src/events/welcomeFlow.ts
+++ b/src/events/welcomeFlow.ts
@@ -1,5 +1,6 @@
 /**
- * Handlers for the two welcome-message buttons (issue #39).
+ * Handlers for the two welcome-message buttons (issue #39) and the setup chain
+ * behind [Start setup] (issue #48).
  *
  * The hard constraint here is delivery: the welcome message is sent by DM to
  * whoever installed the bot, and only falls back to the guild's system channel. In
@@ -8,19 +9,30 @@
  * therefore either work without a guild, or lead the user cleanly back into the
  * server. The guild id rides along in the custom ID so we always know which server
  * "back" means.
+ *
+ * That split runs straight through the setup chain: timezone and language are plain
+ * guild-table columns and can be set from anywhere, but a `RoleSelectMenu` needs a
+ * guild to enumerate roles from. Step 3 therefore renders the "open it in the
+ * server" pointer instead of a broken menu when there is no guild context.
  */
 
 import {
   ActionRowBuilder,
+  ButtonBuilder,
   ButtonInteraction,
+  ButtonStyle,
+  RoleSelectMenuBuilder,
+  RoleSelectMenuInteraction,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
 } from 'discord.js';
 import prisma from '../database/client';
+import { cleanLeaderRoles, formatLeaderRoles, setLanguage, setLeaderRoles } from '../commands/config';
 import { canManageRaids } from '../utils/permissions';
-import { t } from '../utils/localization';
+import { SupportedLanguage, t } from '../utils/localization';
 import {
   COMMON_TIMEZONES,
+  DEFAULT_TIMEZONE,
   formatTimezoneLabel,
   guildTimezoneUpdate,
   normalizeTimezone,
@@ -28,69 +40,160 @@ import {
 import { WELCOME_BUTTON_FIRST_RAID, WELCOME_BUTTON_SETUP } from '../utils/welcomeEmbed';
 
 export const WELCOME_SELECT_TIMEZONE = 'welcome-tz';
+export const WELCOME_SELECT_LANGUAGE = 'welcome-lang';
+export const WELCOME_SELECT_LEADER_ROLES = 'welcome-roles';
+/** `welcome-skip:{guildId}:{step}` — one button per step of the chain. */
+export const WELCOME_BUTTON_SKIP = 'welcome-skip';
 
 /** Discord allows at most 25 options in a select menu. */
 const TIMEZONE_CHOICE_LIMIT = 25;
 
+/** Discord's cap on a role select is 25; ten leader roles is already generous. */
+const LEADER_ROLE_LIMIT = 10;
+
+const TOTAL_STEPS = 3;
+
+type SetupStep = 'tz' | 'lang' | 'roles';
+
+/** Every interaction in the chain edits the same ephemeral message. */
+type ChainInteraction =
+  | ButtonInteraction
+  | StringSelectMenuInteraction
+  | RoleSelectMenuInteraction;
+
 export function isWelcomeButton(customId: string): boolean {
   return (
     customId.startsWith(`${WELCOME_BUTTON_SETUP}:`) ||
-    customId.startsWith(`${WELCOME_BUTTON_FIRST_RAID}:`)
+    customId.startsWith(`${WELCOME_BUTTON_FIRST_RAID}:`) ||
+    customId.startsWith(`${WELCOME_BUTTON_SKIP}:`)
   );
 }
 
 export function isWelcomeSelect(customId: string): boolean {
-  return customId.startsWith(`${WELCOME_SELECT_TIMEZONE}:`);
+  return (
+    customId.startsWith(`${WELCOME_SELECT_TIMEZONE}:`) ||
+    customId.startsWith(`${WELCOME_SELECT_LANGUAGE}:`)
+  );
+}
+
+export function isWelcomeRoleSelect(customId: string): boolean {
+  return customId.startsWith(`${WELCOME_SELECT_LEADER_ROLES}:`);
 }
 
 function guildIdFrom(customId: string): string {
   return customId.split(':')[1] ?? '';
 }
 
+async function guildRow(guildId: string) {
+  return prisma.guild.findUnique({ where: { id: guildId } });
+}
+
 async function guildLanguage(guildId: string): Promise<string> {
-  const guild = await prisma.guild.findUnique({ where: { id: guildId } });
+  const guild = await guildRow(guildId);
   return guild?.language || 'en';
 }
 
+function languageName(language: string): string {
+  return language === 'de' ? 'Deutsch' : 'English';
+}
+
 /**
- * Reply used when a button is pressed in a DM, where nothing guild-scoped can run.
+ * Guild name for a write, resolved from the client cache.
+ *
+ * The setup chain writes through the `/config` helpers, which upsert and therefore
+ * need a name for the create branch. In a DM `interaction.guild` is null, so the
+ * cache is the only source — and the id is a usable last resort, since the create
+ * branch only fires for a guild the bot has never seen.
+ */
+function guildNameFor(interaction: ChainInteraction, guildId: string): string {
+  return interaction.client.guilds.cache.get(guildId)?.name ?? guildId;
+}
+
+/** True when the interaction can enumerate roles for *this* guild. */
+function hasGuildContext(interaction: ChainInteraction, guildId: string): boolean {
+  return Boolean(interaction.guild) && interaction.guildId === guildId;
+}
+
+/**
+ * Body of the "this only works in the server" pointer.
  *
  * Links straight to the server rather than just naming it, so "back into the
  * server" is one tap rather than a hunt through the sidebar.
  */
+function openInServerText(
+  interaction: ChainInteraction,
+  guildId: string,
+  language: string,
+  command: string
+): string {
+  return (
+    t(language, 'welcomeOpenInServer', { guild: guildNameFor(interaction, guildId), command }) +
+    `\nhttps://discord.com/channels/${guildId}`
+  );
+}
+
+/** Reply used when a button is pressed in a DM, where nothing guild-scoped can run. */
 async function replyOpenInServer(
   interaction: ButtonInteraction,
   guildId: string,
   language: string,
   command: string
 ): Promise<void> {
-  const guildName = interaction.client.guilds.cache.get(guildId)?.name ?? guildId;
-
   await interaction.reply({
-    content:
-      t(language, 'welcomeOpenInServer', { guild: guildName, command }) +
-      `\nhttps://discord.com/channels/${guildId}`,
+    content: openInServerText(interaction, guildId, language, command),
     ephemeral: true,
   });
+}
+
+function stepHeader(language: string, current: number): string {
+  return `-# ${t(language, 'welcomeSetupStep', { current, total: TOTAL_STEPS })}`;
+}
+
+function skipRow(
+  guildId: string,
+  step: SetupStep,
+  language: string
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${WELCOME_BUTTON_SKIP}:${guildId}:${step}`)
+      .setLabel(t(language, 'welcomeSetupSkip'))
+      .setStyle(ButtonStyle.Secondary)
+  );
 }
 
 export async function routeWelcomeButton(interaction: ButtonInteraction): Promise<void> {
   if (interaction.customId.startsWith(`${WELCOME_BUTTON_SETUP}:`)) {
     await handleSetupButton(interaction);
+  } else if (interaction.customId.startsWith(`${WELCOME_BUTTON_SKIP}:`)) {
+    await handleSkipButton(interaction);
   } else {
     await handleFirstRaidButton(interaction);
   }
 }
 
+export async function routeWelcomeSelect(
+  interaction: StringSelectMenuInteraction
+): Promise<void> {
+  if (interaction.customId.startsWith(`${WELCOME_SELECT_TIMEZONE}:`)) {
+    await handleTimezoneSelect(interaction);
+  } else {
+    await handleLanguageSelect(interaction);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — timezone
+// ---------------------------------------------------------------------------
+
 /**
- * [Start setup] — asks for the one setting that actually has to be right.
+ * [Start setup] — the one pass through the three settings that are worth asking for.
  *
- * Only the timezone is asked here. Raid roles are chosen per raid, and leader roles
- * have a working default (the Manage Events permission), so neither belongs in a
- * blocking setup step. This is the "dosiert, wenn es relevant ist" from the issue.
+ * All three are relevant exactly once per server: the timezone every raid time is
+ * read in, the language every message is written in, and who may create raids. Each
+ * step is skippable, and each has a working default, so nothing here blocks.
  *
- * Works in a DM: the timezone is a guild-level row, so it can be set without the
- * user being in a guild-context interaction.
+ * Works in a DM up to step 3 — see the module comment.
  */
 async function handleSetupButton(interaction: ButtonInteraction): Promise<void> {
   const guildId = guildIdFrom(interaction.customId);
@@ -107,10 +210,11 @@ async function handleSetupButton(interaction: ButtonInteraction): Promise<void> 
     );
 
   await interaction.reply({
-    content:
-      `${t(language, 'welcomeSetupIntro')}\n\n` +
-      `-# ${t(language, 'welcomeSetupLeaderRolesHint')}`,
-    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+    content: `${stepHeader(language, 1)}\n${t(language, 'welcomeSetupIntro')}`,
+    components: [
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+      skipRow(guildId, 'tz', language),
+    ],
     ephemeral: true,
   });
 }
@@ -135,11 +239,218 @@ export async function handleTimezoneSelect(
     data: guildTimezoneUpdate(timezone),
   });
 
+  await showLanguageStep(
+    interaction,
+    guildId,
+    language,
+    t(language, 'welcomeSetupTimezoneSaved', { zone: formatTimezoneLabel(timezone) })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — language
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders step 2 in place, under the confirmation of step 1.
+ *
+ * The current language is preselected rather than merely mentioned: it was guessed
+ * from the installer's Discord locale at guild-create time (`localeToLanguage`), and
+ * that guess is wrong often enough to be worth putting in front of someone once.
+ */
+async function showLanguageStep(
+  interaction: ChainInteraction,
+  guildId: string,
+  language: string,
+  confirmation: string
+): Promise<void> {
+  const current = language === 'de' ? 'de' : 'en';
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(`${WELCOME_SELECT_LANGUAGE}:${guildId}`)
+    .setPlaceholder(t(language, 'welcomeSetupLanguagePlaceholder'))
+    .addOptions(
+      { label: 'English', value: 'en', default: current === 'en' },
+      { label: 'Deutsch', value: 'de', default: current === 'de' }
+    );
+
   await interaction.update({
-    content: t(language, 'welcomeSetupTimezoneSaved', { zone: formatTimezoneLabel(timezone) }),
+    content:
+      `${confirmation}\n\n` +
+      `${stepHeader(language, 2)}\n` +
+      t(language, 'welcomeSetupLanguageIntro', { detected: languageName(current) }),
+    components: [
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+      skipRow(guildId, 'lang', language),
+    ],
+  });
+}
+
+export async function handleLanguageSelect(
+  interaction: StringSelectMenuInteraction
+): Promise<void> {
+  const guildId = guildIdFrom(interaction.customId);
+  const chosen = interaction.values[0] === 'de' ? 'de' : 'en';
+
+  await setLanguage(guildId, guildNameFor(interaction, guildId), chosen as SupportedLanguage);
+
+  // Everything from here on renders in the language just chosen — that is the point
+  // of asking mid-flow rather than after it.
+  await showLeaderRolesStep(
+    interaction,
+    guildId,
+    chosen,
+    t(chosen, 'welcomeSetupLanguageSaved', { language: languageName(chosen) })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — leader roles
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders step 3, or — without guild context — the pointer back into the server.
+ *
+ * A `RoleSelectMenu` resolves its options against the guild the interaction came
+ * from. In a DM there is none, so showing one would produce an empty, unusable menu.
+ * The chain ends there with a link and the exact command to run instead.
+ */
+async function showLeaderRolesStep(
+  interaction: ChainInteraction,
+  guildId: string,
+  language: string,
+  confirmation: string
+): Promise<void> {
+  if (!hasGuildContext(interaction, guildId)) {
+    await finishSetup(interaction, guildId, language, [
+      confirmation,
+      openInServerText(interaction, guildId, language, '/config leader-roles'),
+    ]);
+    return;
+  }
+
+  const select = new RoleSelectMenuBuilder()
+    .setCustomId(`${WELCOME_SELECT_LEADER_ROLES}:${guildId}`)
+    .setPlaceholder(t(language, 'welcomeSetupLeaderRolesPlaceholder'))
+    // Zero is allowed so an empty submit means the same as [Skip]: keep the default.
+    .setMinValues(0)
+    .setMaxValues(LEADER_ROLE_LIMIT);
+
+  await interaction.update({
+    content:
+      `${confirmation}\n\n` +
+      `${stepHeader(language, 3)}\n` +
+      t(language, 'welcomeSetupLeaderRolesIntro'),
+    components: [
+      new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(select),
+      skipRow(guildId, 'roles', language),
+    ],
+  });
+}
+
+export async function handleLeaderRolesSelect(
+  interaction: RoleSelectMenuInteraction
+): Promise<void> {
+  const guildId = guildIdFrom(interaction.customId);
+  const language = await guildLanguage(guildId);
+
+  // Role IDs, not names: `canManageRaids` matches either, and an ID survives a
+  // rename. `/config view` renders them back as mentions.
+  const roleIds = cleanLeaderRoles(interaction.values.join(','));
+
+  if (!roleIds) {
+    await finishSetup(interaction, guildId, language, [
+      t(language, 'welcomeSetupLeaderRolesSkipped'),
+    ]);
+    return;
+  }
+
+  await setLeaderRoles(guildId, guildNameFor(interaction, guildId), roleIds);
+
+  await finishSetup(interaction, guildId, language, [
+    t(language, 'welcomeSetupLeaderRolesSaved', { roles: formatLeaderRoles(roleIds) }),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Skip — every step is optional
+// ---------------------------------------------------------------------------
+
+async function handleSkipButton(interaction: ButtonInteraction): Promise<void> {
+  const guildId = guildIdFrom(interaction.customId);
+  const step = (interaction.customId.split(':')[2] ?? 'roles') as SetupStep;
+  const guild = await guildRow(guildId);
+  const language = guild?.language || 'en';
+
+  if (step === 'tz') {
+    await showLanguageStep(
+      interaction,
+      guildId,
+      language,
+      t(language, 'welcomeSetupTimezoneSkipped', {
+        zone: formatTimezoneLabel(guild?.timezone || DEFAULT_TIMEZONE),
+      })
+    );
+    return;
+  }
+
+  if (step === 'lang') {
+    await showLeaderRolesStep(
+      interaction,
+      guildId,
+      language,
+      t(language, 'welcomeSetupLanguageSkipped', { language: languageName(language) })
+    );
+    return;
+  }
+
+  await finishSetup(interaction, guildId, language, [
+    t(language, 'welcomeSetupLeaderRolesSkipped'),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Closes the chain with what is now actually stored, read back from the guild row
+ * rather than assembled from what happened to be clicked — a skipped step then shows
+ * the value that was already there instead of a blank.
+ */
+async function finishSetup(
+  interaction: ChainInteraction,
+  guildId: string,
+  language: string,
+  lines: string[]
+): Promise<void> {
+  const guild = await guildRow(guildId);
+  const leaderRoles = cleanLeaderRoles(guild?.raidLeaderRoles || '');
+
+  const summary = [
+    t(language, 'welcomeSetupSummaryTitle'),
+    t(language, 'welcomeSetupSummaryTimezone', {
+      zone: formatTimezoneLabel(guild?.timezone || DEFAULT_TIMEZONE),
+    }),
+    t(language, 'welcomeSetupSummaryLanguage', {
+      language: languageName(guild?.language || language),
+    }),
+    leaderRoles
+      ? t(language, 'welcomeSetupSummaryLeaderRoles', { roles: formatLeaderRoles(leaderRoles) })
+      : t(language, 'welcomeSetupSummaryLeaderRolesDefault'),
+    '',
+    `-# ${t(language, 'welcomeSetupDone')}`,
+  ].join('\n');
+
+  await interaction.update({
+    content: `${lines.join('\n\n')}\n\n${summary}`,
     components: [],
   });
 }
+
+// ---------------------------------------------------------------------------
+// [Create first raid]
+// ---------------------------------------------------------------------------
 
 /**
  * [Create first raid] — the whole point of the welcome message.

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,9 +233,11 @@ client.on(Events.InteractionCreate, async (interaction) => {
       } else if (interaction.isRoleSelectMenu()) {
         if (flow.isFlowRoleSelect(interaction.customId)) {
           await flow.handleRoleSelect(interaction);
+        } else if (welcome.isWelcomeRoleSelect(interaction.customId)) {
+          await welcome.handleLeaderRolesSelect(interaction);
         }
       } else if (welcome.isWelcomeSelect(interaction.customId)) {
-        await welcome.handleTimezoneSelect(interaction);
+        await welcome.routeWelcomeSelect(interaction);
       } else {
         const selectHandler = await import('./events/selectHandler');
         await selectHandler.handleSelectMenu(interaction);

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -242,8 +242,26 @@ export interface Translations {
     welcomeSetupIntro: string;
     welcomeSetupTimezonePlaceholder: string;
     welcomeSetupTimezoneSaved: string;
-    welcomeSetupLeaderRolesHint: string;
     welcomeOpenInServer: string;
+
+    // Welcome setup chain (#48) — timezone → language → leader roles
+    welcomeSetupStep: string;
+    welcomeSetupSkip: string;
+    welcomeSetupTimezoneSkipped: string;
+    welcomeSetupLanguageIntro: string;
+    welcomeSetupLanguagePlaceholder: string;
+    welcomeSetupLanguageSaved: string;
+    welcomeSetupLanguageSkipped: string;
+    welcomeSetupLeaderRolesIntro: string;
+    welcomeSetupLeaderRolesPlaceholder: string;
+    welcomeSetupLeaderRolesSaved: string;
+    welcomeSetupLeaderRolesSkipped: string;
+    welcomeSetupSummaryTitle: string;
+    welcomeSetupSummaryTimezone: string;
+    welcomeSetupSummaryLanguage: string;
+    welcomeSetupSummaryLeaderRoles: string;
+    welcomeSetupSummaryLeaderRolesDefault: string;
+    welcomeSetupDone: string;
 
     // Premium feature display names (localized upsell embed)
     featureRaidOptoutReason: string;
@@ -523,9 +541,26 @@ const translations: Record<SupportedLanguage, Translations> = {
         welcomeTrialTitle: '🎁 {days}-day Premium trial',
         welcomeSetupIntro: '**Which timezone are your raid times in?**\nPick it below — daylight saving is handled automatically.',
         welcomeSetupTimezonePlaceholder: 'Select your timezone',
-        welcomeSetupTimezoneSaved: '✅ Timezone set to **{zone}**.\n\nThat is the only required setting — you can create a raid right now.',
-        welcomeSetupLeaderRolesHint: 'Optional: use `/config leader-roles` to choose who may create raids. Without it, anyone with the *Manage Events* permission can.',
+        welcomeSetupTimezoneSaved: '✅ Timezone set to **{zone}**.',
         welcomeOpenInServer: 'This button only works inside the server. Open **{guild}** and run `{command}` there.',
+
+        welcomeSetupStep: 'Step {current} of {total}',
+        welcomeSetupSkip: 'Skip',
+        welcomeSetupTimezoneSkipped: '⏭️ Timezone left at **{zone}**.',
+        welcomeSetupLanguageIntro: '**Which language should I speak here?**\nWe guessed **{detected}** from your server settings — correct it if that is wrong.',
+        welcomeSetupLanguagePlaceholder: 'Select a language',
+        welcomeSetupLanguageSaved: '✅ Language set to **{language}**.',
+        welcomeSetupLanguageSkipped: '⏭️ Language stays **{language}**.',
+        welcomeSetupLeaderRolesIntro: '**Who may create raids?**\nPick the roles below. Leave it out and anyone with the *Manage Events* permission can.',
+        welcomeSetupLeaderRolesPlaceholder: 'Select raid leader roles',
+        welcomeSetupLeaderRolesSaved: '✅ Raid leader roles: {roles}',
+        welcomeSetupLeaderRolesSkipped: '⏭️ No leader roles set — anyone with *Manage Events* can create raids.',
+        welcomeSetupSummaryTitle: '**Setup complete.**',
+        welcomeSetupSummaryTimezone: 'Timezone: **{zone}**',
+        welcomeSetupSummaryLanguage: 'Language: **{language}**',
+        welcomeSetupSummaryLeaderRoles: 'Raid leaders: {roles}',
+        welcomeSetupSummaryLeaderRolesDefault: 'Raid leaders: anyone with *Manage Events*',
+        welcomeSetupDone: 'Use `/config view` to check or change any of this later.',
 
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Opt-Out Reasons',
@@ -793,9 +828,26 @@ const translations: Record<SupportedLanguage, Translations> = {
         welcomeTrialTitle: '🎁 {days} Tage Premium testen',
         welcomeSetupIntro: '**In welcher Zeitzone sind eure Raid-Zeiten?**\nUnten auswählen – die Sommerzeit wird automatisch berücksichtigt.',
         welcomeSetupTimezonePlaceholder: 'Zeitzone auswählen',
-        welcomeSetupTimezoneSaved: '✅ Zeitzone auf **{zone}** gesetzt.\n\nMehr ist nicht nötig – du kannst sofort einen Raid anlegen.',
-        welcomeSetupLeaderRolesHint: 'Optional: Mit `/config leader-roles` legst du fest, wer Raids anlegen darf. Ohne das darf jeder mit der Berechtigung *Events verwalten*.',
+        welcomeSetupTimezoneSaved: '✅ Zeitzone auf **{zone}** gesetzt.',
         welcomeOpenInServer: 'Dieser Knopf funktioniert nur im Server. Öffne **{guild}** und führe dort `{command}` aus.',
+
+        welcomeSetupStep: 'Schritt {current} von {total}',
+        welcomeSetupSkip: 'Überspringen',
+        welcomeSetupTimezoneSkipped: '⏭️ Zeitzone bleibt bei **{zone}**.',
+        welcomeSetupLanguageIntro: '**In welcher Sprache soll ich hier schreiben?**\nWir haben **{detected}** aus den Server-Einstellungen erkannt – korrigiere es, falls das nicht stimmt.',
+        welcomeSetupLanguagePlaceholder: 'Sprache auswählen',
+        welcomeSetupLanguageSaved: '✅ Sprache auf **{language}** gesetzt.',
+        welcomeSetupLanguageSkipped: '⏭️ Sprache bleibt **{language}**.',
+        welcomeSetupLeaderRolesIntro: '**Wer darf Raids anlegen?**\nWähle unten die Rollen aus. Ohne Auswahl darf jeder mit der Berechtigung *Events verwalten*.',
+        welcomeSetupLeaderRolesPlaceholder: 'Raid-Leiter-Rollen auswählen',
+        welcomeSetupLeaderRolesSaved: '✅ Raid-Leiter-Rollen: {roles}',
+        welcomeSetupLeaderRolesSkipped: '⏭️ Keine Leiter-Rollen gesetzt – jeder mit *Events verwalten* darf Raids anlegen.',
+        welcomeSetupSummaryTitle: '**Einrichtung abgeschlossen.**',
+        welcomeSetupSummaryTimezone: 'Zeitzone: **{zone}**',
+        welcomeSetupSummaryLanguage: 'Sprache: **{language}**',
+        welcomeSetupSummaryLeaderRoles: 'Raid-Leiter: {roles}',
+        welcomeSetupSummaryLeaderRolesDefault: 'Raid-Leiter: jeder mit *Events verwalten*',
+        welcomeSetupDone: 'Mit `/config view` kannst du das alles später prüfen oder ändern.',
 
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Abmeldungsgründe',


### PR DESCRIPTION
Closes #48.

`[Start setup]` asked for the timezone and nothing else. Leader roles were a grey hint line, and the language was never asked — it was guessed from the installer's Discord locale at guild-create time (`localeToLanguage`). Both are relevant exactly once per server, which makes this the cheapest moment to ask.

## What changed

The single select became a three-step chain in one ephemeral message, each step skippable:

1. **Timezone** — `StringSelectMenu` over `COMMON_TIMEZONES`, as before
2. **Language** — `StringSelectMenu` (`en`/`de`) with the guessed value preselected via `default: true`, framed as "we guessed X, correct it if that is wrong"
3. **Leader roles** — `RoleSelectMenu`, `minValues: 0` so an empty submit means the same as `[Skip]`: keep the *Manage Events* default

Each step confirms in place via `interaction.update()` and renders the next one underneath. The chain closes with a summary read back **from the guild row** — so a skipped step shows the value that was already stored rather than a blank — plus the pointer to `/config view`.

Picking a language mid-flow re-renders the remaining steps in that language immediately.

## The DM path

The welcome message is delivered by DM, where `interaction.guild` is `null`. Timezone and language are plain guild columns and set fine from there. A `RoleSelectMenu` resolves its options against the guild the interaction came from, so in a DM it would render as an empty, unusable menu. Step 3 therefore checks `interaction.guild && interaction.guildId === guildId` and otherwise ends the chain with the `welcomeOpenInServer` text, the channel link and the exact command (`/config leader-roles`). The same check also catches the case where the DM button is pressed from a *different* server the user installed the bot into.

## One writer per column

Per the issue: `guildTimezoneUpdate` was already shared. For the other two, the upsert bodies were extracted out of `src/commands/config.ts` into exported `setLanguage()` / `setLeaderRoles()` (plus `cleanLeaderRoles()`), and the `/config` subcommands now call the same helpers. No column gained a second write site.

## Two notes where the issue's assumptions did not survive contact with the code

- **`replyOpenInServer` could not be reused verbatim.** The issue asks step 3 to "fall back to `replyOpenInServer(… '/config leader-roles')`". That helper takes a `ButtonInteraction` and calls `.reply()`, which would post a *second* ephemeral message next to the chain instead of closing it. The message body was factored out into `openInServerText()`; `replyOpenInServer` still exists unchanged for the `[Create first raid]` button, and the chain renders the same text through its `update()`.
- **Leader roles are stored as IDs, and `/config view` had to change to keep the acceptance criterion honest.** A `RoleSelectMenu` yields snowflakes, and IDs are the better thing to store (`canManageRaids` matches IDs or names, and an ID survives a rename). But `/config view` printed `raidLeaderRoles` raw inside code ticks, so it would have shown a row of bare numbers — technically "genau das Gesetzte", practically unreadable. `formatLeaderRoles()` now renders snowflake entries as role mentions and leaves names in ticks. This is a rendering change to an existing command, called out here because it is slightly outside the issue's stated scope.

`welcomeSetupLeaderRolesHint` lost its last caller (the hint line it produced is now step 3) and was removed from both locales rather than left as a dead key. `welcomeSetupTimezoneSaved` lost its trailing "that is the only required setting" sentence, which is no longer true mid-chain.

## Verification

`npm run build` and `npm test` (`tsc --noEmit`) clean; `npm run test:jest` green at 1166 passing. `welcomeFlow.test.ts` grew to 27 tests covering both paths: guild (all three steps, IDs written through the upsert helper, summary) and DM (step 3 points into the server, no role menu rendered), plus each skip, the empty-role-select no-write case, and the mid-flow language switch taking effect on step 3.

Not verified by me: the flow has not been clicked through against a live Discord server — the DM behaviour is covered by the interaction shapes the tests assert, not by a real DM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)