### PR TITLE
Geführter /raid create: Ping der ausgewählten Rollen umschaltbar machen (#49)

### DIFF
--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -82,7 +82,7 @@ async function resolveDefaultTeamId(guildId: string): Promise<string> {
  *          Returns empty string if no valid roles are found. 
  *          Invalid roles are logged as warnings and excluded from the result.
  */
-function buildRoleMentions(guild: Guild, roleIds: string[]): string {
+export function buildRoleMentions(guild: Guild, roleIds: string[]): string {
   const roleMentions = roleIds
     .map((roleIdOrName) => {
       const trimmed = roleIdOrName.trim();

--- a/src/events/__tests__/raidCreateFlow.test.ts
+++ b/src/events/__tests__/raidCreateFlow.test.ts
@@ -8,7 +8,11 @@
 
 jest.mock('../../database/client');
 jest.mock('../../utils/permissions');
+// Only the write is stubbed. `buildRoleMentions` is a pure resolver over the guild's
+// role cache and the preview's ping line is only worth asserting against the real
+// one — a hand-written stand-in would drift from it.
 jest.mock('../../commands/raid', () => ({
+  ...jest.requireActual('../../commands/raid'),
   createRaidWithRoster: jest.fn().mockResolvedValue(true),
 }));
 
@@ -21,6 +25,7 @@ import {
   handleDetailsSubmit,
   handleFixTimeButton,
   handleFixTimeSubmit,
+  handlePingToggle,
   handleRoleSelect,
   isFlowButton,
   isFlowModal,
@@ -74,10 +79,22 @@ function buildRoleSelectInteraction(customId: string, values: string[], userId =
     values,
     user: { id: userId },
     guildId: GUILD_ID,
+    guild: { id: GUILD_ID, roles: roleCache() },
     isModalSubmit: () => false,
     update: jest.fn().mockResolvedValue(undefined),
     reply: jest.fn().mockResolvedValue(undefined),
   } as any;
+}
+
+/**
+ * Role cache the preview resolves mentions against — `buildRoleMentions` drops role
+ * ids the guild does not know, so the fixture has to carry them.
+ */
+function roleCache() {
+  const roles = new Map<string, any>();
+  roles.set('role-a', { id: 'role-a', name: 'Raider' });
+  roles.set('role-b', { id: 'role-b', name: 'Trial' });
+  return { cache: Object.assign(roles, { find: (fn: any) => [...roles.values()].find(fn) }) };
 }
 
 function buildButtonInteraction(customId: string, userId = USER_ID) {
@@ -89,7 +106,8 @@ function buildButtonInteraction(customId: string, userId = USER_ID) {
     user: { id: userId },
     guildId: GUILD_ID,
     member: {},
-    guild: { id: GUILD_ID, channels: { cache: channelCache } },
+    guild: { id: GUILD_ID, channels: { cache: channelCache }, roles: roleCache() },
+    isModalSubmit: () => false,
     showModal: jest.fn().mockResolvedValue(undefined),
     deferUpdate: jest.fn().mockResolvedValue(undefined),
     update: jest.fn().mockResolvedValue(undefined),
@@ -301,7 +319,7 @@ describe('guided /raid create flow', () => {
       expect(embed.description).toContain('Europe/Berlin');
     });
 
-    it('offers a confirm and a correct-time button', async () => {
+    it('offers a confirm, a correct-time and a ping button', async () => {
       const { draftId } = await runToRoleSelect();
       const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
 
@@ -311,7 +329,21 @@ describe('guided /raid create flow', () => {
       expect(buttons.map((b: any) => b.custom_id)).toEqual([
         `rcflow-confirm:${draftId}`,
         `rcflow-fixtime:${draftId}`,
+        `rcflow-ping:${draftId}`,
       ]);
+    });
+
+    it('starts with the ping off — unchanged behaviour for the guided path', async () => {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+
+      await handleRoleSelect(select);
+
+      const update = select.update.mock.calls[0][0];
+      const pingButton = update.components[0].toJSON().components[2];
+      expect(pingButton.label).toBe('Ping: off');
+      expect(pingButton.disabled).toBe(false);
+      expect(update.embeds[0].toJSON().description).toContain('No ping');
     });
 
     it('converts the typed time using the guild zone, with DST applied', async () => {
@@ -335,6 +367,134 @@ describe('guided /raid create flow', () => {
 
       expect(new Date(winter * 1000).toISOString()).toBe('2035-01-17T19:00:00.000Z'); // CET
       expect(new Date(summer * 1000).toISOString()).toBe('2035-07-17T18:00:00.000Z'); // CEST
+    });
+  });
+
+  // Issue #49: the guided path could pick roles but not decide whether they get
+  // notified — the question only becomes answerable once the roles are chosen.
+  describe('step 3b — the ping toggle', () => {
+    /** Runs the flow up to a preview with the given roles and returns the draft id. */
+    async function runToPreview(roles: string[] = ['role-a']) {
+      const { draftId } = await runToRoleSelect();
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, roles);
+      await handleRoleSelect(select);
+      return { draftId, select };
+    }
+
+    it('flips the draft and re-renders the preview with the actual mentions', async () => {
+      const { draftId } = await runToPreview(['role-a', 'role-b']);
+      const button = buildButtonInteraction(`rcflow-ping:${draftId}`);
+
+      await handlePingToggle(button);
+
+      const update = button.update.mock.calls[0][0];
+      expect(update.components[0].toJSON().components[2].label).toBe('Ping: on');
+      const description = update.embeds[0].toJSON().description;
+      expect(description).toContain('pinged');
+      expect(description).toContain('<@&role-a>');
+      expect(description).toContain('<@&role-b>');
+    });
+
+    it('flips back off on a second press', async () => {
+      const { draftId } = await runToPreview();
+
+      await handlePingToggle(buildButtonInteraction(`rcflow-ping:${draftId}`));
+      const second = buildButtonInteraction(`rcflow-ping:${draftId}`);
+      await handlePingToggle(second);
+
+      expect(second.update.mock.calls[0][0].components[0].toJSON().components[2].label).toBe(
+        'Ping: off'
+      );
+    });
+
+    // Acceptance criterion: the slash option still sets the prefill and arrives as "on".
+    it('shows "on" when ping_roles:true came in on the command line', async () => {
+      const slash = buildSlashInteraction();
+      await startGuidedRaidCreate(slash, {
+        date: null,
+        time: null,
+        title: null,
+        roles: null,
+        pingRoles: true,
+        teamOption: null,
+      });
+
+      const draftId = draftIdFromModal(slash);
+      await handleDetailsSubmit(
+        buildModalInteraction(`rcflow-details:${draftId}`, {
+          title: 'Heroic Night',
+          date: futureDate(),
+          time: '20:00',
+        })
+      );
+      const select = buildRoleSelectInteraction(`rcflow-roles:${draftId}`, ['role-a']);
+      await handleRoleSelect(select);
+
+      const update = select.update.mock.calls[0][0];
+      expect(update.components[0].toJSON().components[2].label).toBe('Ping: on');
+      expect(update.embeds[0].toJSON().description).toContain('pinged');
+    });
+
+    // Acceptance criterion: without roles the toggle must not be operable — disabled
+    // rather than clickable-but-inconsequential.
+    it('renders disabled and refuses to flip when no role was picked', async () => {
+      const { draftId, select } = await runToPreview([]);
+
+      expect(select.update.mock.calls[0][0].components[0].toJSON().components[2].disabled).toBe(
+        true
+      );
+
+      const button = buildButtonInteraction(`rcflow-ping:${draftId}`);
+      await handlePingToggle(button);
+
+      expect(button.deferUpdate).toHaveBeenCalled();
+      expect(button.update).not.toHaveBeenCalled();
+    });
+
+    // The whole point: the flag has to survive to the post, not just to the preview.
+    it('carries through to the created raid', async () => {
+      const { draftId } = await runToPreview();
+
+      await handlePingToggle(buildButtonInteraction(`rcflow-ping:${draftId}`));
+      await handleConfirmButton(buildButtonInteraction(`rcflow-confirm:${draftId}`));
+
+      expect(createRaidWithRoster).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ pingRoles: true, roleIds: ['role-a'] })
+      );
+    });
+
+    it('posts without the ping when the toggle was never touched', async () => {
+      const { draftId } = await runToPreview();
+
+      await handleConfirmButton(buildButtonInteraction(`rcflow-confirm:${draftId}`));
+
+      expect(createRaidWithRoster).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ pingRoles: false })
+      );
+    });
+
+    it('clears the stale preview when the draft has expired', async () => {
+      const button = buildButtonInteraction('rcflow-ping:doesnotexist');
+
+      await handlePingToggle(button);
+
+      expect(button.update).toHaveBeenCalledWith(
+        expect.objectContaining({ components: [], embeds: [] })
+      );
+    });
+
+    // A custom ID is visible to anyone who can see the message.
+    it('ignores a toggle pressed by someone else', async () => {
+      const { draftId } = await runToPreview();
+      const button = buildButtonInteraction(`rcflow-ping:${draftId}`, 'someone-else');
+
+      await handlePingToggle(button);
+
+      expect(button.update).toHaveBeenCalledWith(
+        expect.objectContaining({ components: [], embeds: [] })
+      );
     });
   });
 

--- a/src/events/raidCreateFlow.ts
+++ b/src/events/raidCreateFlow.ts
@@ -33,8 +33,9 @@ import {
   TextInputStyle,
 } from 'discord.js';
 import prisma from '../database/client';
-import { createRaidWithRoster } from '../commands/raid';
+import { buildRoleMentions, createRaidWithRoster } from '../commands/raid';
 import { canManageRaids } from '../utils/permissions';
+import { t } from '../utils/localization';
 import {
   DEFAULT_TIMEZONE,
   formatInTimezone,
@@ -54,6 +55,7 @@ export const MODAL_FIXTIME = 'rcflow-fixtime-modal';
 export const SELECT_ROLES = 'rcflow-roles';
 export const BUTTON_CONFIRM = 'rcflow-confirm';
 export const BUTTON_FIXTIME = 'rcflow-fixtime';
+export const BUTTON_PING = 'rcflow-ping';
 
 interface RaidDraft {
   guildId: string;
@@ -118,6 +120,15 @@ export function __clearDrafts(): void {
 async function guildTimezone(guildId: string): Promise<string> {
   const guild = await prisma.guild.findUnique({ where: { id: guildId } });
   return guild?.timezone || DEFAULT_TIMEZONE;
+}
+
+/** Both settings the preview needs, in one query. */
+async function guildSettings(guildId: string): Promise<{ timezone: string; language: string }> {
+  const guild = await prisma.guild.findUnique({ where: { id: guildId } });
+  return {
+    timezone: guild?.timezone || DEFAULT_TIMEZONE,
+    language: guild?.language || 'en',
+  };
 }
 
 /**
@@ -309,21 +320,32 @@ export async function handleRoleSelect(interaction: RoleSelectMenuInteraction): 
  * self-correcting, and it is why issue #37 deferred this piece to this flow.
  */
 async function showPreview(
-  interaction: RoleSelectMenuInteraction | ModalSubmitInteraction,
+  interaction: RoleSelectMenuInteraction | ModalSubmitInteraction | ButtonInteraction,
   draftId: string,
   draft: RaidDraft
 ): Promise<void> {
-  const timezone = await guildTimezone(draft.guildId);
+  const { timezone, language } = await guildSettings(draft.guildId);
   const raidDate = zonedDateTimeToUtc(draft.date, draft.time, timezone)!;
   const unix = Math.floor(raidDate.getTime() / 1000);
+
+  const hasRoles = draft.roleIds.length > 0;
+
+  // Resolved against the guild so the preview shows exactly the mentions that will
+  // go out — a role deleted since the select drops out here rather than at post time.
+  const mentions = interaction.guild
+    ? buildRoleMentions(interaction.guild, draft.roleIds)
+    : draft.roleIds.map((id) => `<@&${id}>`).join(' ');
 
   const embed = new EmbedBuilder()
     .setTitle(`📋 ${draft.title}`)
     .setColor(0x00ae86)
     .setDescription(
       `**When:** <t:${unix}:F> (<t:${unix}:R>)\n` +
-      `**Roles:** ${draft.roleIds.map((id) => `<@&${id}>`).join(' ')}\n\n` +
-      `_Entered as ${draft.time} in ${formatTimezoneLabel(timezone)}. ` +
+      `**Roles:** ${draft.roleIds.map((id) => `<@&${id}>`).join(' ')}\n` +
+      (draft.pingRoles && hasRoles
+        ? `${t(language, 'raidCreatePingEnabled', { roles: mentions })}\n`
+        : `${t(language, 'raidCreatePingDisabled')}\n`) +
+      `\n_Entered as ${draft.time} in ${formatTimezoneLabel(timezone)}. ` +
       'The time above is shown in your own Discord timezone — if it looks wrong, ' +
       'fix the server timezone below._'
     );
@@ -336,7 +358,14 @@ async function showPreview(
     new ButtonBuilder()
       .setCustomId(`${BUTTON_FIXTIME}:${draftId}`)
       .setLabel('Fix time / timezone')
+      .setStyle(ButtonStyle.Secondary),
+    // Nothing to ping without roles, so the toggle is dead weight rather than a
+    // control that flips a flag with no effect.
+    new ButtonBuilder()
+      .setCustomId(`${BUTTON_PING}:${draftId}`)
+      .setLabel(t(language, draft.pingRoles ? 'raidCreatePingOn' : 'raidCreatePingOff'))
       .setStyle(ButtonStyle.Secondary)
+      .setDisabled(!hasRoles)
   );
 
   const payload = { content: '', embeds: [embed], components: [buttons] };
@@ -346,6 +375,46 @@ async function showPreview(
   } else {
     await interaction.update(payload);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Step 3b — the ping toggle
+// ---------------------------------------------------------------------------
+
+/**
+ * Flips `draft.pingRoles` and re-renders the preview.
+ *
+ * The question — should the chosen roles get a notification? — only becomes
+ * answerable once the roles are chosen, and it has no defensible default: a regular
+ * weekly raid usually should not ping, a short-notice replacement mostly should. The
+ * slash option `ping_roles:true` still sets the prefill, so this toggle starts at
+ * whatever the command line said and can still be flipped.
+ *
+ * Touches the in-memory draft only — nothing is persisted before [Create raid].
+ */
+export async function handlePingToggle(interaction: ButtonInteraction): Promise<void> {
+  const draftId = interaction.customId.split(':')[1];
+  const draft = getDraft(draftId, interaction.user.id);
+
+  if (!draft) {
+    await interaction.update({
+      content: '⏱️ This setup has expired. Run `/raid create` again — it only takes a moment.',
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  // The button is rendered disabled without roles; this guards the case where the
+  // click and the render race each other.
+  if (draft.roleIds.length === 0) {
+    await interaction.deferUpdate();
+    return;
+  }
+
+  draft.pingRoles = !draft.pingRoles;
+
+  await showPreview(interaction, draftId, draft);
 }
 
 // ---------------------------------------------------------------------------
@@ -542,7 +611,11 @@ export function isFlowModal(customId: string): boolean {
 }
 
 export function isFlowButton(customId: string): boolean {
-  return customId.startsWith(`${BUTTON_CONFIRM}:`) || customId.startsWith(`${BUTTON_FIXTIME}:`);
+  return (
+    customId.startsWith(`${BUTTON_CONFIRM}:`) ||
+    customId.startsWith(`${BUTTON_FIXTIME}:`) ||
+    customId.startsWith(`${BUTTON_PING}:`)
+  );
 }
 
 export function isFlowRoleSelect(customId: string): boolean {
@@ -560,6 +633,8 @@ export async function routeFlowModal(interaction: ModalSubmitInteraction): Promi
 export async function routeFlowButton(interaction: ButtonInteraction): Promise<void> {
   if (interaction.customId.startsWith(`${BUTTON_CONFIRM}:`)) {
     await handleConfirmButton(interaction);
+  } else if (interaction.customId.startsWith(`${BUTTON_PING}:`)) {
+    await handlePingToggle(interaction);
   } else {
     await handleFixTimeButton(interaction);
   }

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -245,6 +245,12 @@ export interface Translations {
     welcomeSetupLeaderRolesHint: string;
     welcomeOpenInServer: string;
 
+    // Guided /raid create — ping toggle in the preview (#49)
+    raidCreatePingOn: string;
+    raidCreatePingOff: string;
+    raidCreatePingEnabled: string;
+    raidCreatePingDisabled: string;
+
     // Premium feature display names (localized upsell embed)
     featureRaidOptoutReason: string;
     featureRaidArchive: string;
@@ -527,6 +533,11 @@ const translations: Record<SupportedLanguage, Translations> = {
         welcomeSetupLeaderRolesHint: 'Optional: use `/config leader-roles` to choose who may create raids. Without it, anyone with the *Manage Events* permission can.',
         welcomeOpenInServer: 'This button only works inside the server. Open **{guild}** and run `{command}` there.',
 
+        raidCreatePingOn: 'Ping: on',
+        raidCreatePingOff: 'Ping: off',
+        raidCreatePingEnabled: '🔔 These roles get pinged when the raid is posted: {roles}',
+        raidCreatePingDisabled: '🔕 No ping — the raid is posted without notifying anyone.',
+
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Opt-Out Reasons',
         featureRaidArchive: 'Raid Archive',
@@ -796,6 +807,11 @@ const translations: Record<SupportedLanguage, Translations> = {
         welcomeSetupTimezoneSaved: '✅ Zeitzone auf **{zone}** gesetzt.\n\nMehr ist nicht nötig – du kannst sofort einen Raid anlegen.',
         welcomeSetupLeaderRolesHint: 'Optional: Mit `/config leader-roles` legst du fest, wer Raids anlegen darf. Ohne das darf jeder mit der Berechtigung *Events verwalten*.',
         welcomeOpenInServer: 'Dieser Knopf funktioniert nur im Server. Öffne **{guild}** und führe dort `{command}` aus.',
+
+        raidCreatePingOn: 'Ping: an',
+        raidCreatePingOff: 'Ping: aus',
+        raidCreatePingEnabled: '🔔 Diese Rollen werden beim Posten angepingt: {roles}',
+        raidCreatePingDisabled: '🔕 Kein Ping – der Raid wird gepostet, ohne jemanden zu benachrichtigen.',
 
         // Premium feature display names (localized upsell embed)
         featureRaidOptoutReason: 'Abmeldungsgründe',


### PR DESCRIPTION
Closes #49.

`pingRoles` was already threaded through the guided flow's draft, but nothing could set it: the prefill came from the slash options and `[Create first raid]` starts at `false`. So the guided path — the audience #38 was built for — could pick roles but not decide whether those roles get notified.

## What changed

A third button in the preview, next to `[Create raid]` and `[Fix time / timezone]`:

- `Ping: off` / `Ping: on`, `ButtonStyle.Secondary`, flips `draft.pingRoles` and re-renders the preview
- Default **off** — the guided flow's current behaviour, so nothing changes for existing guilds
- With the ping on, the preview names the roles that will actually be mentioned, resolved through `buildRoleMentions` against the guild's role cache, so a role deleted since the select drops out here rather than at post time. With it off, the preview says so explicitly rather than staying silent about it.
- Disabled when the draft has no roles

The toggle touches the in-memory draft only. Custom ID carries the `draftId` like every other step, so `pruneExpiredDrafts` and the "someone else's draft" check apply unchanged. The slash path is untouched: `ping_roles:true` still sets the prefill, the preview then opens on `Ping: on`, and it can still be flipped.

`showPreview` now reads language alongside timezone in one query (`guildSettings`) — the new strings go through `t(language, …)` in `en` and `de`, the pre-existing English copy in that embed was left as it was rather than half-localised in passing.

## Two notes on the issue's assumptions

- **`buildRoleMentions` was not exported.** The issue points at `src/commands/raid.ts:85` as if it were reusable; it was module-private. It is now exported, which is the only change to `raid.ts`.
- **"No roles picked" is not reachable through the UI today.** The issue treats it as a normal case to handle. In the current flow it cannot happen: the role select is `setMinValues(1)`, and `showPreview` is only reached after it. The button is rendered `disabled` and `handlePingToggle` also `deferUpdate()`s on an empty draft, so both the requirement and a future flow that relaxes the minimum are covered — but no user can reach that state right now. Flagging it rather than implementing it silently.

## Verification

`npm run build` and `npm test` (`tsc --noEmit`) clean; `npm run test:jest` green at 1162 passing. `raidCreateFlow.test.ts` gained a `step 3b` block: flip on (with the real mentions in the preview), flip back off, `ping_roles:true` arriving as "on", disabled + no-op without roles, expired draft, foreign draft, and — the one that matters — `pingRoles: true` surviving all the way into the `createRaidWithRoster` call, plus `false` when the toggle is never touched.

The `commands/raid` mock now spreads `jest.requireActual` so the preview's ping line is asserted against the real `buildRoleMentions` rather than a stand-in that could drift from it; `createRaidWithRoster` stays stubbed.

Not verified by me: not clicked through against a live Discord server. That the ping itself reaches Discord is existing `createRaidWithRoster` behaviour, unchanged here — this PR only verifies the flag arrives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)