### PR TITLE
Welcome ueber den System-Channel zustellen statt das Audit-Log zu lesen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The welcome message goes to the system channel first and falls back to a DM to the server owner. It no longer reads the audit log to find who invited the bot — that needs View Audit Log, which the invite does not request, so the lookup failed on every install and the message went to the system channel regardless. The system channel is now the intended path rather than an accident, and it reaches every raid leader instead of one person
+
 ## [0.8.0] - 2026-08-07
 
 ### Added

--- a/src/events/welcomeFlow.ts
+++ b/src/events/welcomeFlow.ts
@@ -2,13 +2,13 @@
  * Handlers for the two welcome-message buttons (issue #39) and the setup chain
  * behind [Start setup] (issue #48).
  *
- * The hard constraint here is delivery: the welcome message is sent by DM to
- * whoever installed the bot, and only falls back to the guild's system channel. In
- * a DM the interaction has **no guild context** — `interaction.guild` is null and
- * the member (and therefore their roles) is unavailable. Both buttons must
- * therefore either work without a guild, or lead the user cleanly back into the
- * server. The guild id rides along in the custom ID so we always know which server
- * "back" means.
+ * The hard constraint here is delivery: the welcome message goes to the guild's
+ * system channel, and falls back to a DM to the server owner when there is none or
+ * the bot may not post there (#52). In that DM the interaction has **no guild
+ * context** — `interaction.guild` is null and the member (and therefore their
+ * roles) is unavailable. Both buttons must therefore either work without a guild,
+ * or lead the user cleanly back into the server. The guild id rides along in the
+ * custom ID so we always know which server "back" means.
  *
  * That split runs straight through the setup chain: timezone and language are plain
  * guild-table columns and can be set from anywhere, but a `RoleSelectMenu` needs a

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,68 +308,49 @@ client.on(Events.GuildCreate, async (guild) => {
   console.log(`🌍 ${guild.name} starts on UTC. Use /config timezone to set the server's zone.`);
 
   // Send welcome/setup message
+  //
+  // Delivery order is system channel first, owner DM as the fallback (#52).
+  //
+  // This used to read the audit log to find who invited the bot and DM them. That
+  // needs View Audit Log, which the invite deliberately does not request — reading a
+  // server's moderation history is far more access than a greeting is worth. The
+  // call therefore always failed and the message always went to the system channel
+  // anyway; now that is the intended path rather than an accident. It also reaches
+  // every raid leader instead of one person.
   try {
-    const { AuditLogEvent } = await import('discord.js');
-
     // Localize the welcome embed to the guild's Discord locale (brand-new guilds
     // have no `language` config row yet), so a German server gets German copy.
     const language = localeToLanguage(guild.preferredLocale);
-    // Buttons carry the guild id: the primary delivery path is a DM, where the
-    // interaction has no guild context of its own (#39).
+    // Buttons carry the guild id: the owner-DM fallback has no guild context of its
+    // own, so the handlers cannot infer which server they are acting on (#39).
     const welcomeMessage = buildWelcomeMessage({
       trialGranted,
       language,
       guildId: guild.id,
     });
 
-    // Try to find who added the bot via audit logs
-    let botAdder = null;
-    try {
-      const auditLogs = await guild.fetchAuditLogs({
-        type: AuditLogEvent.BotAdd,
-        limit: 5,
-      });
-
-      const botAddEntry = auditLogs.entries.find(
-        (entry) => entry.target?.id === client.user?.id
-      );
-
-      if (botAddEntry) {
-        botAdder = botAddEntry.executor;
-        console.log(`📋 Bot was added by: ${botAdder?.tag}`);
-      }
-    } catch (error) {
-      console.log(`⚠️  Could not fetch audit logs for ${guild.name}`);
-    }
-
-    // Try to send DM to person who added the bot
     let messageSent = false;
 
-    if (botAdder) {
-      try {
-        await botAdder.send(welcomeMessage);
-        messageSent = true;
-        console.log(`📨 Sent welcome DM to ${botAdder.tag} (added the bot) in ${guild.name}`);
-      } catch (error) {
-        console.log(`⚠️  Could not DM ${botAdder.tag} (DMs disabled or blocked)`);
-      }
-    }
-
-    // Fallback: Try system channel
-    if (!messageSent && guild.systemChannel && guild.systemChannel.permissionsFor(guild.members.me!)?.has('SendMessages')) {
+    if (
+      guild.systemChannel &&
+      guild.systemChannel.permissionsFor(guild.members.me!)?.has('SendMessages')
+    ) {
       await guild.systemChannel.send(welcomeMessage);
       messageSent = true;
       console.log(`📨 Sent welcome message to system channel in ${guild.name}`);
     }
 
-    // Final fallback: Try to DM the owner
+    // No system channel, or no permission to post in it: fall back to the owner's
+    // DMs. This is the path the welcome flow's DM handling exists for.
     if (!messageSent) {
       try {
         const owner = await guild.fetchOwner();
         await owner.send(welcomeMessage);
-        console.log(`📨 Sent welcome DM to owner of ${guild.name}`);
+        console.log(`📨 Sent welcome DM to owner of ${guild.name} (no usable system channel)`);
       } catch (error) {
-        console.log(`❌ Could not send welcome message to ${guild.name}`);
+        console.log(
+          `❌ Could not send welcome message to ${guild.name}: no usable system channel and the owner's DMs are closed`
+        );
       }
     }
   } catch (error) {


### PR DESCRIPTION
Umsetzung von **Option B** aus #52, nach Entscheidung von Chris.

## Was war

`GuildCreate` las das Audit-Log, um den Einladenden zu finden und ihm die Welcome-DM zu schicken. Das braucht **View Audit Log** — eine Berechtigung, die der Invite-Link (`permissions=117760`) bewusst nicht anfordert. Der Aufruf scheiterte damit bei *jeder* Installation, `botAdder` blieb `null`, und die Zustellung fiel stillschweigend auf den System-Channel durch. Belegt im Prod-Log des Testservers nach v0.8.0:

```
⚠️  Could not fetch audit logs for Server von chrisyy
📨 Sent welcome message to system channel in Server von chrisyy
```

## Was jetzt

System-Channel zuerst, Owner-DM als Fallback. Der Audit-Log-Pfad ist raus.

Begründung für B statt A (Berechtigung nachfordern): Das Audit-Log ist die Moderations-Historie eines Servers. Dafür Lesezugriff zu verlangen, nur um einen Namen für eine Begrüßung zu bekommen, ist ein schlechter Tausch — besonders im Invite-Dialog, den ein Admin vor der Installation sieht, bei einem Bot dessen Argument die niedrige Einstiegshürde ist. Der System-Channel erreicht zudem alle Raidleiter statt einer Person.

Die DM-Sonderbehandlung in der Setup-Kette (#48) bleibt: der Owner-Fallback erreicht sie weiterhin. Sie ist nur nicht mehr der erwartete Weg — die Kommentare in `index.ts` und `welcomeFlow.ts` beschrieben die Reihenfolge bisher andersherum und sind mitgezogen.

Die Fehlermeldung im letzten Fallback nennt jetzt den Grund (kein nutzbarer System-Channel *und* geschlossene Owner-DMs), statt nur „could not send".

## Verifikation

`npx tsc --noEmit` sauber, 1175 Tests grün.

**Manuell gegenzuklicken nach dem Deploy:** frischer Testserver → Welcome erscheint im System-Channel. Für den DM-Pfad: System-Channel in den Servereinstellungen auf „Kein" setzen, Bot neu einladen → DM an den Owner.

Closes #52