### PR TITLE
feat(guilds): record departures so kicks stop counting as live installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Guild departures are recorded. `Guild.leftAt` is NULL while the bot is in a server and holds a timestamp once it is out, so a live install can finally be told apart from a dead one — the row itself has always survived a kick, since raids, teams and preferences cascade off it and deleting them would lose a server's history on every re-install. A `guildDelete` handler stamps the field, `guildCreate` clears it again and logs the re-install with how long the server had been gone
+- Startup reconciliation: guilds that are still marked live in the database but no longer in the gateway's guild cache get stamped at boot, which catches kicks that happened while the bot was down
+
+### Changed
+- The trial backfill no longer treats servers the bot was kicked from as candidates — the trial is one-time, so granting it to a dead install would spend it before anyone could use it
+
+### Notes
+- **The first boot after this ships stamps a large batch of guilds at once, and that is expected.** Measured read-only on production on 2026-08-09: 116 `Guild` rows against 48 servers actually reachable via Discord, i.e. 68 departures that were never recorded. The reconciliation marks all 68 with the deploy timestamp. `leftAt` is defined as *when the departure was detected*, not when it happened, so those 68 are years of accumulated churn landing on one date — do not read them as 68 servers leaving in a single day. Every departure recorded after this deploy is accurate to the second
+- Every usage number produced before this change counted database rows and was therefore too optimistic by roughly 59%
+
 ## [0.8.1] - 2026-08-09
 
 ### Changed

--- a/prisma/migrations/20260809120000_guild_left_at/migration.sql
+++ b/prisma/migrations/20260809120000_guild_left_at/migration.sql
@@ -1,0 +1,20 @@
+-- Adds `Guild.leftAt` so a guild the bot was kicked from can be told apart from a
+-- live one. Until now nothing recorded departures: the row simply stayed behind, and
+-- every "how many servers use this bot" number counted dead installs as live ones.
+-- Measured read-only on production on 2026-08-09: 116 Guild rows, 48 guilds actually
+-- reachable via GET /users/@me/guilds — 59% of the rows were stale.
+--
+-- ADDITIVE AND NON-DESTRUCTIVE: nothing is deleted and no existing row is rewritten.
+-- Every row starts at NULL, i.e. "assumed live", and the startup reconciliation in
+-- src/index.ts stamps the ones that are not in the gateway's guild cache on the first
+-- boot after deploy. Doing it in the application rather than here is deliberate — the
+-- database has no way of knowing which guilds Discord still hands us.
+--
+-- RE-RUNNABLE: both statements are guarded, so a partially applied attempt can simply
+-- be replayed.
+
+ALTER TABLE "Guild" ADD COLUMN IF NOT EXISTS "leftAt" TIMESTAMP(3);
+
+-- Every guild count filters on `leftAt` from here on, and the reconciliation scans
+-- `leftAt IS NULL` on every boot.
+CREATE INDEX IF NOT EXISTS "Guild_leftAt_idx" ON "Guild"("leftAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,15 @@ model Guild {
   timezoneOffset  Int      @default(0) // DEPRECATED, phase 1 of the IANA migration. Nothing reads this any more; it is kept written (guildTimezoneUpdate()) purely as a rollback path and is dropped in phase 2.
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+  // NULL = the bot is currently in this guild; set = the bot is out (kicked, or the
+  // guild was deleted). Rows are never removed, so this is the only thing that tells
+  // a live install apart from a dead one — every guild count must filter on it.
+  //
+  // SEMANTICS: this is the timestamp at which the departure was *detected*, not
+  // necessarily when it happened. A kick observed live via guildDelete lands within
+  // seconds; one found by the startup reconciliation is stamped at boot time and may
+  // be weeks late. Never read it as an exact churn date.
+  leftAt          DateTime?
 
   // Archive system fields (Phase 2.4)
   archiveChannelId String?  // Guild's designated archive channel
@@ -39,6 +48,9 @@ model Guild {
   users UserPreference[]
   rolePreferences UserRolePreference[]
   teams Team[]
+
+  // Every usage count and every candidate query filters on `leftAt` from here on.
+  @@index([leftAt])
 }
 
 model Team {

--- a/src/__tests__/backfillTrials.test.ts
+++ b/src/__tests__/backfillTrials.test.ts
@@ -24,7 +24,7 @@ describe('backfillTrials', () => {
     await backfillTrials();
 
     expect(guildMock.findMany).toHaveBeenCalledWith({
-      where: { trialStartedAt: null, entitlementId: null, premiumTier: 'FREE' },
+      where: { trialStartedAt: null, entitlementId: null, premiumTier: 'FREE', leftAt: null },
       select: { id: true, name: true },
     });
   });

--- a/src/__tests__/guildLifecycle.test.ts
+++ b/src/__tests__/guildLifecycle.test.ts
@@ -1,0 +1,210 @@
+jest.mock('../database/client');
+
+import prisma from '../database/client';
+import {
+  syncGuildOnJoin,
+  markGuildDeparted,
+  reconcileDepartedGuilds,
+} from '../services/guildLifecycle';
+
+const guildMock = (prisma as any).guild;
+
+const NOW = new Date('2026-08-09T12:00:00.000Z');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  guildMock.findUnique.mockResolvedValue(null);
+  guildMock.upsert.mockResolvedValue({});
+  guildMock.updateMany.mockResolvedValue({ count: 0 });
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('markGuildDeparted', () => {
+  it('does not stamp leftAt when the guild is merely unavailable (Discord outage)', async () => {
+    const stamped = await markGuildDeparted(
+      { id: 'g1', name: 'Alpha', available: false },
+      { now: NOW },
+    );
+
+    expect(stamped).toBe(false);
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+    expect(guildMock.update).not.toHaveBeenCalled();
+  });
+
+  it('logs the outage case instead of silently ignoring it', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await markGuildDeparted({ id: 'g1', name: 'Alpha', available: false }, { now: NOW });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('temporarily unavailable'));
+  });
+
+  it('stamps leftAt when the guild is available, i.e. a real kick', async () => {
+    guildMock.updateMany.mockResolvedValue({ count: 1 });
+
+    const stamped = await markGuildDeparted(
+      { id: 'g1', name: 'Alpha', available: true },
+      { now: NOW },
+    );
+
+    expect(stamped).toBe(true);
+    expect(guildMock.updateMany).toHaveBeenCalledWith({
+      where: { id: 'g1', leftAt: null },
+      data: { leftAt: NOW },
+    });
+  });
+
+  it('treats a payload without an `available` flag as a real departure', async () => {
+    await markGuildDeparted({ id: 'g1', name: 'Alpha' }, { now: NOW });
+
+    expect(guildMock.updateMany).toHaveBeenCalledWith({
+      where: { id: 'g1', leftAt: null },
+      data: { leftAt: NOW },
+    });
+  });
+
+  it('never deletes the guild row or its related data', async () => {
+    await markGuildDeparted({ id: 'g1', name: 'Alpha', available: true }, { now: NOW });
+
+    // Raids/teams/preferences cascade off the Guild row, so the row must survive.
+    expect((prisma as any).raid.deleteMany).not.toHaveBeenCalled();
+    expect((prisma as any).raid.delete).not.toHaveBeenCalled();
+    expect(guildMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it('leaves an already-recorded departure in place (duplicate event is a no-op)', async () => {
+    // The `leftAt: null` predicate is what makes this safe — the DB matches nothing.
+    guildMock.updateMany.mockResolvedValue({ count: 0 });
+
+    await markGuildDeparted({ id: 'g1', name: 'Alpha', available: true }, { now: NOW });
+
+    expect(guildMock.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ leftAt: null }) }),
+    );
+  });
+});
+
+describe('syncGuildOnJoin', () => {
+  it('clears leftAt on the update branch so a returning guild counts as live', async () => {
+    guildMock.findUnique.mockResolvedValue({ leftAt: new Date('2026-07-10T00:00:00.000Z') });
+
+    await syncGuildOnJoin({ id: 'g1', name: 'Alpha' }, { now: NOW });
+
+    expect(guildMock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'g1' },
+        update: { name: 'Alpha', leftAt: null },
+      }),
+    );
+  });
+
+  it('reports a row with a set leftAt as a re-install', async () => {
+    const leftAt = new Date('2026-07-30T12:00:00.000Z');
+    guildMock.findUnique.mockResolvedValue({ leftAt });
+
+    const result = await syncGuildOnJoin({ id: 'g1', name: 'Alpha' }, { now: NOW });
+
+    expect(result).toEqual({ rejoined: true, previousLeftAt: leftAt });
+  });
+
+  it('logs how long a re-installing guild was away', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    guildMock.findUnique.mockResolvedValue({ leftAt: new Date('2026-07-30T12:00:00.000Z') });
+
+    await syncGuildOnJoin({ id: 'g1', name: 'Alpha' }, { now: NOW });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Re-install'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('10 day(s)'));
+  });
+
+  it('does not report a re-install for a guild that never left', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    guildMock.findUnique.mockResolvedValue({ leftAt: null });
+
+    const result = await syncGuildOnJoin({ id: 'g1', name: 'Alpha' }, { now: NOW });
+
+    expect(result).toEqual({ rejoined: false, previousLeftAt: null });
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('Re-install'));
+  });
+
+  it('creates a fresh row for a first install without a leftAt value', async () => {
+    guildMock.findUnique.mockResolvedValue(null);
+
+    const result = await syncGuildOnJoin({ id: 'g2', name: 'Beta' }, { now: NOW });
+
+    expect(result.rejoined).toBe(false);
+    expect(guildMock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ id: 'g2', name: 'Beta' }),
+      }),
+    );
+    // A brand-new row is live by definition; leftAt stays at its NULL default.
+    expect(guildMock.upsert.mock.calls[0][0].create).not.toHaveProperty('leftAt');
+  });
+});
+
+describe('reconcileDepartedGuilds', () => {
+  it('stamps only rows that are still live and not in the cache', async () => {
+    guildMock.updateMany.mockResolvedValue({ count: 2 });
+
+    const count = await reconcileDepartedGuilds(['g1', 'g2'], { now: NOW });
+
+    expect(count).toBe(2);
+    expect(guildMock.updateMany).toHaveBeenCalledWith({
+      where: { leftAt: null, id: { notIn: ['g1', 'g2'] } },
+      data: { leftAt: NOW },
+    });
+  });
+
+  it('leaves already-stamped rows alone via the leftAt: null predicate', async () => {
+    await reconcileDepartedGuilds(['g1'], { now: NOW });
+
+    const where = guildMock.updateMany.mock.calls[0][0].where;
+    expect(where.leftAt).toBeNull();
+  });
+
+  it('accepts an iterable such as the gateway cache keys', async () => {
+    const cache = new Map([
+      ['g1', {}],
+      ['g2', {}],
+    ]);
+
+    await reconcileDepartedGuilds(cache.keys(), { now: NOW });
+
+    expect(guildMock.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { leftAt: null, id: { notIn: ['g1', 'g2'] } } }),
+    );
+  });
+
+  it('writes nothing when the guild cache is empty', async () => {
+    // `notIn: []` would match every row and wipe out the whole install base.
+    const count = await reconcileDepartedGuilds([], { now: NOW });
+
+    expect(count).toBe(0);
+    expect(guildMock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('logs the number of departures it recorded', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    guildMock.updateMany.mockResolvedValue({ count: 68 });
+
+    await reconcileDepartedGuilds(['g1'], { now: NOW });
+
+    expect(log).toHaveBeenCalledWith('🚪 Reconciliation: 68 guild(s) marked as departed');
+  });
+
+  it('stays quiet when nothing changed', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    guildMock.updateMany.mockResolvedValue({ count: 0 });
+
+    await reconcileDepartedGuilds(['g1'], { now: NOW });
+
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('Reconciliation'));
+  });
+});

--- a/src/database/__mocks__/client.ts
+++ b/src/database/__mocks__/client.ts
@@ -32,6 +32,7 @@ const prisma: Record<string, any> = {
     update: jest.fn(),
     updateMany: jest.fn(),
     upsert: jest.fn(),
+    count: jest.fn().mockResolvedValue(0),
   },
   team: {
     // Default team resolution succeeds out of the box so raid fixtures get a teamId

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { buildWelcomeMessage } from './utils/welcomeEmbed';
 import { getDefaultTeam } from './services/teamService';
 import { TEAM_OPTION_NAME } from './utils/teamContext';
 import { runStartupTrialBackfill } from './scripts/backfillTrials';
+import { syncGuildOnJoin, markGuildDeparted, reconcileDepartedGuilds } from './services/guildLifecycle';
 import { logInteraction, commandLabel } from './utils/interactionLog';
 
 config();
@@ -60,18 +61,9 @@ client.once(Events.ClientReady, async (c) => {
     // No timezone detection: Discord's `preferredLocale` is a language setting, not
     // a location, so deriving a zone from it produced confident nonsense. New guilds
     // start at UTC and set their zone explicitly via `/config timezone`.
-    await prisma.guild.upsert({
-      where: { id: guildId },
-      update: {
-        name: guild.name,
-      },
-      create: {
-        id: guildId,
-        name: guild.name,
-        raidRoles: process.env.RAID_ROLES || '',
-        raidLeaderRoles: process.env.RAID_LEADER_ROLES || '',
-      },
-    });
+    // Also clears `leftAt`: everything in the cache is a guild the bot is currently in,
+    // so a row that was marked departed while the bot was down is live again.
+    await syncGuildOnJoin({ id: guildId, name: guild.name });
 
     // Make sure every guild owns its default "Main" team. Never abort startup
     // over this — the team is created lazily on first raid creation anyway.
@@ -81,6 +73,16 @@ client.once(Events.ClientReady, async (c) => {
       console.error(`❌ Failed to ensure default team for ${guild.name}:`, error);
     }
 
+  }
+
+  // Anything still marked live in the database but missing from the cache is a guild
+  // the bot is no longer in — a kick during downtime, or (on the first boot after this
+  // shipped) a historical one that was never recorded. Runs after the sync loop above so
+  // every cached guild has already had its `leftAt` cleared and cannot be caught here.
+  try {
+    await reconcileDepartedGuilds(c.guilds.cache.keys());
+  } catch (error) {
+    console.error('❌ Guild departure reconciliation failed:', error);
   }
 
   console.log('✅ Guild data synchronized');
@@ -272,19 +274,9 @@ client.on(Events.InteractionCreate, async (interaction) => {
 client.on(Events.GuildCreate, async (guild) => {
   console.log(`➕ Joined new guild: ${guild.name} (${guild.id})`);
 
-  // Upsert so a re-install (where the guild row persists) never throws and
-  // never clobbers the server's existing configuration. New guilds default to
-  // UTC — see the guild-sync block above for why nothing is auto-detected.
-  await prisma.guild.upsert({
-    where: { id: guild.id },
-    update: { name: guild.name },
-    create: {
-      id: guild.id,
-      name: guild.name,
-      raidRoles: process.env.RAID_ROLES || '',
-      raidLeaderRoles: process.env.RAID_LEADER_ROLES || '',
-    },
-  });
+  // Upserts, clears any `leftAt` mark, and logs the re-install case. New guilds
+  // default to UTC — see the guild-sync block above for why nothing is auto-detected.
+  await syncGuildOnJoin({ id: guild.id, name: guild.name });
 
   // Make sure the guild owns its default "Main" team right away.
   try {
@@ -355,6 +347,20 @@ client.on(Events.GuildCreate, async (guild) => {
     }
   } catch (error) {
     console.error('Error sending welcome message:', error);
+  }
+});
+
+// Guild departure
+//
+// Records the kick instead of deleting anything: the guild's raids, teams and
+// preferences stay on disk so a re-install finds its history intact. `markGuildDeparted`
+// ignores the event when the guild is merely unavailable during a Discord outage —
+// see the function's comment, that distinction is what keeps the number meaningful.
+client.on(Events.GuildDelete, async (guild) => {
+  try {
+    await markGuildDeparted({ id: guild.id, name: guild.name, available: guild.available });
+  } catch (error) {
+    console.error(`❌ Failed to mark guild ${guild.id} as departed:`, error);
   }
 });
 

--- a/src/scripts/backfillTrials.ts
+++ b/src/scripts/backfillTrials.ts
@@ -43,6 +43,11 @@ export async function backfillTrials(
       trialStartedAt: null,
       entitlementId: null,
       premiumTier: 'FREE',
+      // Guilds the bot has been kicked from keep their row forever. Handing them the
+      // one-time trial would burn it on a server nobody is in — and since the grant is
+      // one-time, a later re-install would find it already spent. A returning guild has
+      // its `leftAt` cleared on guildCreate and becomes a candidate again on the next run.
+      leftAt: null,
     },
     select: { id: true, name: true },
   });

--- a/src/scripts/extendTrials.ts
+++ b/src/scripts/extendTrials.ts
@@ -78,6 +78,10 @@ export async function extendTrials(
   const dryRun = options.dryRun ?? true;
   const now = options.now ?? new Date();
 
+  // Deliberately not filtered on `leftAt`: this is a one-off correction that already ran
+  // on production, and it only rewrites `premiumExpiresAt` on rows that *already* hold a
+  // trial. Skipping departed guilds would change nothing about the live install base but
+  // would leave a re-installing guild sitting on the old, shorter expiry.
   const candidates = await prisma.guild.findMany({
     where: {
       trialStartedAt: { not: null },

--- a/src/services/guildLifecycle.ts
+++ b/src/services/guildLifecycle.ts
@@ -1,0 +1,173 @@
+import prisma from '../database/client';
+
+/**
+ * Tracking of guild joins and departures.
+ *
+ * The bot never deletes a `Guild` row when it is kicked — raids, teams and user
+ * preferences hang off it via `ON DELETE CASCADE`, and a re-install would lose a
+ * server's entire history. The row therefore outlives the install, and `leftAt` is
+ * the only thing that separates the two states: NULL means the bot is in the guild,
+ * a timestamp means it is out.
+ *
+ * `leftAt` records when the departure was *detected*. A live `guildDelete` is exact
+ * to the second; a departure found by the startup reconciliation is stamped at boot
+ * and can be arbitrarily late. See the comment on the schema field.
+ */
+
+/** The minimal shape both `guildCreate` and `guildDelete` supply. */
+export interface GuildLifecyclePayload {
+  id: string;
+  name: string;
+  /**
+   * discord.js sets this to `false` while a guild is unreachable due to an outage.
+   * `undefined` is treated as available — partial payloads default to the live case.
+   */
+  available?: boolean;
+}
+
+export interface GuildJoinResult {
+  /** True when the row already existed with a `leftAt` set, i.e. this is a re-install. */
+  rejoined: boolean;
+  /** The previous `leftAt`, or null for a first install or an uninterrupted row. */
+  previousLeftAt: Date | null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Writes the guild row for a join (or a startup sync) and clears any departure mark.
+ *
+ * Upsert, so a re-install never throws and never clobbers the server's existing
+ * configuration. `leftAt: null` in the update branch is what makes a returning guild
+ * count as live again.
+ *
+ * @returns whether this was a re-install, plus how long the guild had been gone.
+ */
+export async function syncGuildOnJoin(
+  guild: GuildLifecyclePayload,
+  options: { now?: Date } = {},
+): Promise<GuildJoinResult> {
+  const now = options.now ?? new Date();
+
+  // Read before the write: the upsert clears `leftAt`, so afterwards there is no way
+  // to tell a re-install from a plain sync. A stale read is harmless here — it only
+  // decides whether a log line is printed, never what is written.
+  const existing = await prisma.guild.findUnique({
+    where: { id: guild.id },
+    select: { leftAt: true },
+  });
+
+  await prisma.guild.upsert({
+    where: { id: guild.id },
+    update: {
+      name: guild.name,
+      // The bot is demonstrably in this guild right now, so any departure mark —
+      // from a real kick or from a reconciliation pass — is obsolete.
+      leftAt: null,
+    },
+    create: {
+      id: guild.id,
+      name: guild.name,
+      raidRoles: process.env.RAID_ROLES || '',
+      raidLeaderRoles: process.env.RAID_LEADER_ROLES || '',
+    },
+  });
+
+  const previousLeftAt = existing?.leftAt ?? null;
+
+  if (previousLeftAt) {
+    const days = Math.max(0, Math.round((now.getTime() - previousLeftAt.getTime()) / DAY_MS));
+    console.log(
+      `♻️ Re-install: ${guild.name} (${guild.id}) is back after ${days} day(s) away ` +
+        `(departure detected ${previousLeftAt.toISOString()})`,
+    );
+  }
+
+  return { rejoined: previousLeftAt !== null, previousLeftAt };
+}
+
+/**
+ * Marks a guild as departed after a `guildDelete` event.
+ *
+ * WHY THE `available` CHECK IS THE WHOLE POINT: Discord fires `guildDelete` for two
+ * completely different things. One is a real departure (kick, ban, guild deleted).
+ * The other is a guild going *temporarily unreachable* during a Discord outage or a
+ * gateway node moving — and those arrive with `available === false`, followed later by
+ * a `guildCreate` when the guild comes back. Stamping on the second case would let a
+ * single Discord incident mark the entire install base as kicked in the space of a few
+ * seconds, and because `leftAt` records a detection time there is nothing in the data
+ * to undo that with afterwards. The metric would be permanently worthless. So an
+ * unavailable guild is logged and nothing else.
+ *
+ * @returns true when the row was stamped, false when the event was an outage.
+ */
+export async function markGuildDeparted(
+  guild: GuildLifecyclePayload,
+  options: { now?: Date } = {},
+): Promise<boolean> {
+  if (guild.available === false) {
+    console.log(
+      `⚠️ Guild temporarily unavailable (Discord outage), not marking as departed: ` +
+        `${guild.name} (${guild.id})`,
+    );
+    return false;
+  }
+
+  const now = options.now ?? new Date();
+
+  // updateMany, not update: a guildDelete for a guild that was never written (e.g. the
+  // bot was removed before the first sync) must not throw P2025 inside an event handler.
+  // The `leftAt: null` predicate also makes a duplicate event a no-op instead of moving
+  // an already-recorded departure forward.
+  await prisma.guild.updateMany({
+    where: { id: guild.id, leftAt: null },
+    data: { leftAt: now },
+  });
+
+  // Nothing is deleted here on purpose: raids, teams and preferences stay untouched so
+  // a re-install finds its history intact. The cascade relations are never triggered.
+  console.log(`➖ Left guild: ${guild.name} (${guild.id})`);
+
+  return true;
+}
+
+/**
+ * Stamps every guild row that still looks live but is not in the gateway's cache.
+ *
+ * Catches the two cases `guildDelete` cannot: kicks that happened while the bot was
+ * down, and — on the first boot after this feature ships — every historical kick that
+ * was never recorded at all. Those all get the current timestamp, which is correct in
+ * the "detected at" sense the field is defined with, but means the first run produces
+ * one large same-second batch rather than a real churn history.
+ *
+ * @param activeGuildIds ids from `client.guilds.cache`.
+ * @returns the number of rows newly marked as departed.
+ */
+export async function reconcileDepartedGuilds(
+  activeGuildIds: Iterable<string>,
+  options: { now?: Date } = {},
+): Promise<number> {
+  const ids = [...activeGuildIds];
+
+  // Refuse to run on an empty cache. `notIn: []` matches every row, so a gateway that
+  // handed us no guilds — a bad connect, a token problem — would mark the entire
+  // install base as departed in one statement. A genuine zero-guild bot loses nothing
+  // by skipping: the next real departure is still caught by guildDelete.
+  if (ids.length === 0) {
+    console.warn('⚠️ Reconciliation skipped: guild cache is empty');
+    return 0;
+  }
+
+  const now = options.now ?? new Date();
+
+  const { count } = await prisma.guild.updateMany({
+    where: { leftAt: null, id: { notIn: ids } },
+    data: { leftAt: now },
+  });
+
+  if (count > 0) {
+    console.log(`🚪 Reconciliation: ${count} guild(s) marked as departed`);
+  }
+
+  return count;
+}


### PR DESCRIPTION
## Problem

The bot has a `guildCreate` handler and nothing on the other side. A kick leaves no trace: the `Guild` row stays (correctly — raids, teams and preferences cascade off it, so deleting it would wipe a server's history on every re-install), and nothing distinguishes it from a live install.

Measured read-only on production on 2026-08-09, after the v0.8.1 deploy: **116 `Guild` rows, 48 guilds actually reachable** via `GET /users/@me/guilds`. 68 guilds (59%) had kicked the bot without it being recorded anywhere. Every usage baseline so far counted rows and was that much too optimistic.

## Changes

**Schema + migration** — `Guild.leftAt DateTime?` plus an index on it. NULL = the bot is in the guild, set = it is out. Additive only: no existing row is rewritten, nothing is dropped, both statements are guarded so a partial apply can be replayed. The field is documented in the schema as a **detection** time, not the real departure time — a live `guildDelete` is exact, a reconciliation find can be weeks late.

**`Events.GuildDelete`** — stamps `leftAt` and logs `➖ Left guild: …`. Uses `updateMany` with a `leftAt: null` predicate so a duplicate event is a no-op and an event for an unknown guild does not throw P2025 inside a handler.

**The `available === false` guard — the critical bit.** Discord fires `guildDelete` for two unrelated things: a real departure, and a guild going temporarily unreachable during an outage or a gateway node move. The second arrives with `available === false` and is followed by a `guildCreate` when it recovers. Stamping it would let one Discord incident mark the entire install base as kicked in a few seconds, and since `leftAt` records a *detection* time there is nothing in the data to reconstruct the truth from afterwards — the metric would be permanently worthless. Unavailable guilds are logged and nothing else. Reasoned out in the code comment on `markGuildDeparted()`.

**`GuildCreate`** — the upsert's `update` branch now sets `leftAt: null`. The prior value is read first, so a row that had a departure mark is logged as a re-install including how many days it was away. That signal would otherwise be silently overwritten.

**Startup reconciliation** — after the existing guild-sync loop, every row with `leftAt IS NULL` whose id is not in `client.guilds.cache` is stamped, logged as `🚪 Reconciliation: X guild(s) marked as departed`. Catches kicks during downtime and, on the first boot after this ships, the 68 historical ones. It refuses to run on an empty cache: `notIn: []` matches every row, so a bad gateway connect would otherwise mark the whole install base as departed in one statement.

The event logic lives in `src/services/guildLifecycle.ts` rather than inline in `index.ts` — `index.ts` runs `client.login()` at import time and cannot be unit-tested; the handlers are three-line delegations.

**Nothing is deleted.** The cascade relations are unchanged and are never triggered.

## Existing counts (scope item 5)

Repo-wide search for reads that implicitly assume every `Guild` row is a live guild. Only two bulk sites exist; there is no stats or premium path that counts guilds.

- `src/scripts/backfillTrials.ts` — **filtered.** The Premium trial is one-time, so granting it to a server the bot was kicked from spends it on nobody, and a later re-install finds it already used. A returning guild has its `leftAt` cleared on `guildCreate` and becomes a candidate again on the next boot.
- `src/scripts/extendTrials.ts` — **deliberately not filtered**, with a comment saying why. It is a one-off correction that already ran on production, and it only rewrites `premiumExpiresAt` on rows that already hold a trial. Filtering would change nothing about the live install base but would leave a re-installing guild on the old, shorter expiry.
- `entitlementService.grantTrialIfEligible()` — targeted `updateMany` by a single id from a live event. Not a count, no change.
- `📊 Serving ${c.guilds.cache.size} guild(s)` — comes from the client, already correct, untouched.

## Note for whoever reads the numbers later

The first boot after deploy stamps all 68 historical departures with the deploy timestamp. That is correct under "detected at", but it is years of churn landing on one date and must not be read as 68 servers leaving in a single day. Called out explicitly in the CHANGELOG. Everything recorded after that deploy is accurate to the second.

## Verification

- `npx tsc --noEmit` — clean
- Full suite — **1192 passed, 0 failed** (1175 before, +17 here)
- 17 new tests in `src/__tests__/guildLifecycle.test.ts`, covering the four required cases: `available === false` does not stamp, `available === true` does, `guildCreate` resets a set `leftAt` to NULL, and reconciliation stamps only uncached rows while leaving stamped ones alone — plus the empty-cache guard, the re-install log, and that no delete path is reachable.

Not tagged and not released, per the brief — a `v*` tag triggers auto-deploy with `prisma migrate deploy` on 87.106.209.41, and there is no DB backup. Timing is Chris's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)