### PR TITLE
fix(premium): gate scheduler auto-archive behind raid.archive entitlement

### DIFF
--- a/src/utils/__tests__/integration/raidScheduler-autoArchive.integration.test.ts
+++ b/src/utils/__tests__/integration/raidScheduler-autoArchive.integration.test.ts
@@ -19,9 +19,16 @@ jest.mock('../../archiveManager');
 jest.mock('../../../commands/raid', () => ({
   createRaidEmbed: jest.fn(),
 }));
+// Auto-archive is premium-gated; these fallback scenarios assume an entitled guild, so
+// only the DB-backed tier lookup is faked (hasFeature/FEATURE_TIERS stay real).
+jest.mock('../../../services/entitlementService', () => ({
+  ...jest.requireActual('../../../services/entitlementService'),
+  getTier: jest.fn(),
+}));
 
 // Now safe to import mocked modules
 const prisma = require('../../../database/client').default;
+const { getTier } = require('../../../services/entitlementService');
 const { archiveRaid } = require('../../archiveManager');
 const { createRaidEmbed } = require('../../../commands/raid');
 const { checkAndCloseExpiredRaids } = require('../../raidScheduler');
@@ -50,6 +57,8 @@ describe('Auto-Archive Scheduler Integration Tests', () => {
       findMany: jest.fn(),
       update: jest.fn(),
     };
+
+    (getTier as jest.Mock<any>).mockResolvedValue('PREMIUM');
 
     // Setup createRaidEmbed mock
     (createRaidEmbed as jest.Mock<any>).mockResolvedValue({

--- a/src/utils/__tests__/raidScheduler.test.ts
+++ b/src/utils/__tests__/raidScheduler.test.ts
@@ -11,12 +11,19 @@ jest.mock('../../commands/raid', () => ({
 jest.mock('../teamContext', () => ({
   getTeamLabel: jest.fn(),
 }));
+// Only the DB-backed tier lookup is faked; hasFeature/FEATURE_TIERS stay real so these
+// tests break if `raid.archive` ever changes tier.
+jest.mock('../../services/entitlementService', () => ({
+  ...jest.requireActual('../../services/entitlementService'),
+  getTier: jest.fn(),
+}));
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import prisma from '../../database/client';
 import { archiveRaid } from '../archiveManager';
 import { createRaidEmbed } from '../../commands/raid';
 import { getTeamLabel } from '../teamContext';
+import { getTier } from '../../services/entitlementService';
 
 describe('raidScheduler', () => {
   let mockClient: any;
@@ -48,6 +55,9 @@ describe('raidScheduler', () => {
 
     // Default: single-team guild -> no team is named anywhere
     (getTeamLabel as jest.Mock<any>).mockResolvedValue(null);
+
+    // Default: entitled guild, so the pre-existing auto-archive cases behave as before.
+    (getTier as jest.Mock<any>).mockResolvedValue('PREMIUM');
   });
 
   afterEach(() => {
@@ -232,6 +242,102 @@ describe('raidScheduler', () => {
 
       // Verify: archiveRaid should NOT be called
       expect(archiveRaid).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkAndCloseExpiredRaids - Premium gate on auto-archive', () => {
+    const raidId = 'raid-gate';
+    const guildId = 'guild-gate';
+
+    /** Guild with auto-archive fully configured — the only variable is the tier. */
+    const makeArchivableRaid = (): any => ({
+      id: raidId,
+      guildId,
+      description: 'Test Raid',
+      raidDate: new Date(Date.now() - 1000),
+      status: 'open',
+      messageId: 'message-gate',
+      channelId: 'channel-gate',
+      guild: {
+        id: guildId,
+        autoArchive: true,
+        archiveChannelId: 'archive-gate',
+        language: 'en',
+      },
+    });
+
+    let mockMessage: any;
+
+    beforeEach(() => {
+      (prisma.raid.findMany as jest.Mock<any>).mockResolvedValue([makeArchivableRaid()]);
+      (prisma.raid.update as jest.Mock<any>).mockResolvedValue(makeArchivableRaid());
+      (archiveRaid as jest.Mock<any>).mockResolvedValue(undefined);
+
+      mockMessage = { edit: jest.fn().mockResolvedValue(undefined) };
+      mockClient.channels.fetch.mockResolvedValue({
+        isTextBased: () => true,
+        messages: { fetch: jest.fn().mockResolvedValue(mockMessage) },
+        send: jest.fn().mockResolvedValue(undefined),
+      });
+    });
+
+    it('archives the raid when the guild has premium', async () => {
+      (getTier as jest.Mock<any>).mockResolvedValue('PREMIUM');
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(archiveRaid).toHaveBeenCalledWith(raidId, guildId, mockClient);
+      expect(prisma.raid.update).toHaveBeenCalledWith({
+        where: { id: raidId },
+        data: { status: 'closed' },
+      });
+    });
+
+    it('does NOT archive the raid when the guild is on the free tier', async () => {
+      (getTier as jest.Mock<any>).mockResolvedValue('FREE');
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(archiveRaid).not.toHaveBeenCalled();
+
+      // The raid still closes — only the archiving is withheld.
+      expect(prisma.raid.update).toHaveBeenCalledWith({
+        where: { id: raidId },
+        data: { status: 'closed' },
+      });
+
+      // Falls back to the normal close path: buttons stripped from the original message.
+      expect(mockMessage.edit).toHaveBeenCalledWith({
+        embeds: expect.any(Array),
+        components: [],
+      });
+    });
+
+    it('skips quietly — no message is sent to the guild and nothing throws', async () => {
+      (getTier as jest.Mock<any>).mockResolvedValue('FREE');
+      const channel = await mockClient.channels.fetch();
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await expect(checkAndCloseExpiredRaids(mockClient)).resolves.not.toThrow();
+
+      // No upsell/warning spam: a scheduler pass runs every two minutes.
+      expect(channel.send).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the tier lookup errors', async () => {
+      (getTier as jest.Mock<any>).mockRejectedValue(new Error('db down'));
+
+      const { checkAndCloseExpiredRaids } = require('../raidScheduler');
+      await checkAndCloseExpiredRaids(mockClient);
+
+      expect(archiveRaid).not.toHaveBeenCalled();
+      expect(prisma.raid.update).toHaveBeenCalledWith({
+        where: { id: raidId },
+        data: { status: 'closed' },
+      });
     });
   });
 

--- a/src/utils/raidScheduler.ts
+++ b/src/utils/raidScheduler.ts
@@ -3,6 +3,7 @@ import prisma, { withRetry } from '../database/client';
 import { createRaidEmbed } from '../commands/raid';
 import { archiveRaid } from './archiveManager';
 import { getTeamLabel } from './teamContext';
+import { FEATURE_TIERS, getTier, hasFeature } from '../services/entitlementService';
 import { advanceSeries, retireNudge, sendPostRaidNudge } from '../services/recurringRaidService';
 import { NUDGE_LOOKBACK_MS, NUDGE_TTL_MS, RECURRENCE_WEEKLY } from './recurrence';
 
@@ -116,7 +117,32 @@ export async function checkAndCloseExpiredRaids(client: Client) {
        const teamLabel = teamSuffix(await getTeamLabel(raid.guildId, raid.teamId));
 
          // Check if auto-archive is enabled for this guild
-         const shouldAutoArchive = !!(raid.guild.autoArchive && raid.guild.archiveChannelId);
+         const autoArchiveConfigured = !!(raid.guild.autoArchive && raid.guild.archiveChannelId);
+
+         // Auto-archive is the background twin of `/raid archive`, so it has to honour the
+         // same `raid.archive` entitlement. Without this check a guild whose trial lapsed
+         // keeps archiving forever and never sees the upsell the manual paths show.
+         // Skipped quietly on purpose: there is no interaction to reply to here, and a
+         // scheduler pass must not message the guild every two minutes. The raid still
+         // closes normally below — only the archiving is withheld.
+         let shouldAutoArchive = autoArchiveConfigured;
+         if (autoArchiveConfigured) {
+           try {
+             const tier = await getTier(raid.guildId);
+             if (!hasFeature(tier, 'raid.archive')) {
+               shouldAutoArchive = false;
+               console.log(
+                 `⏭️ Skipped auto-archive for raid ${raid.id} — guild ${raid.guildId} is on ${tier}, 'raid.archive' requires ${FEATURE_TIERS['raid.archive']}`,
+               );
+             }
+           } catch (tierError) {
+             // Fail closed: an unreadable tier must not hand out a premium feature. The
+             // raid still closes; the next pass re-evaluates once the lookup recovers.
+             shouldAutoArchive = false;
+             console.error(`⚠️ Tier lookup failed for guild ${raid.guildId}, skipping auto-archive:`, tierError);
+           }
+         }
+
          let archivedSuccessfully = false;
 
         // If auto-archive is enabled, archive the raid


### PR DESCRIPTION
## Problem

`checkAndCloseExpiredRaids` in `src/utils/raidScheduler.ts` archived expired raids based **only** on the guild's `autoArchive` + `archiveChannelId` config — no tier check at all. The three manual paths all gate on the same feature:

- `/raid archive` → `gateFeature(interaction, 'raid.archive', …)` (`src/commands/raid.ts:1719`)
- `/raid unarchive` → same (`src/commands/raid.ts:1764`)
- `/raid search` → same (`src/commands/raid.ts:1823`)

`FEATURE_TIERS['raid.archive'] === 'PREMIUM'`, so a guild whose trial or subscription lapsed lost the three commands but silently kept automatic archiving forever.

> [!IMPORTANT]
> **3 live guilds lose a feature with this merge.** Guilds that are currently on FREE with `autoArchive` still enabled stop getting their expired raids archived. Their raids still close normally — only the copy into the archive channel is withheld. There is no announcement to them from this PR; if we want to notify them, that is a separate follow-up.

## Behaviour before / after

| | before | after |
|---|---|---|
| PREMIUM guild, auto-archive on | raid closed + archived | unchanged — raid closed + archived |
| FREE guild, auto-archive on | **raid closed + archived** (leak) | raid closed, archive skipped, buttons stripped from original message as usual |
| FREE guild, manual `/raid archive` | blocked with upsell embed | unchanged |
| Tier lookup fails (DB blip) | n/a | fails closed — no archive, raid still closes, retried next pass |

The skip is **quiet by design**: the scheduler has no interaction to attach an upsell embed to, and the pass runs every two minutes, so any guild-facing message would be spam. The skip is recorded on the operator console only:

```
⏭️ Skipped auto-archive for raid <id> — guild <id> is on FREE, 'raid.archive' requires PREMIUM
```

## Other background paths — checked, none affected

`src/utils/raidScheduler.ts:47` is the only `setInterval` in the codebase. Its other three passes (`processRecurringSeries`, `sendPostRaidNudges`, `expireStaleNudges`) drive recurring raids and nudges, which were deliberately made FREE-tier and are not in `FEATURE_TIERS` — nothing to gate. Every other gated feature (`stats.*`, `raid.template`, `raid.integrations`, `team.multi`, `raid.optout_reason`) is only reachable from command/button handlers, which already gate. **No further unguarded background paths found.** Nothing outside the auto-archive path was changed.

## Tests

New `checkAndCloseExpiredRaids - Premium gate on auto-archive` block in `src/utils/__tests__/raidScheduler.test.ts`:

- guild with premium → raid is archived
- guild without premium → raid is **not** archived, still closes, falls back to the normal message update
- skip is quiet — no channel send, no error log, does not throw
- tier lookup error → fails closed

The two existing auto-archive suites now mock `getTier` to `PREMIUM` (only the DB-backed lookup is faked; `hasFeature`/`FEATURE_TIERS` stay real, so the tests break if `raid.archive` ever changes tier).

`npx tsc --noEmit` clean · `npx jest` 1249 passed, 0 failed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)